### PR TITLE
Report n_triggered_events also for emitter simulations

### DIFF
--- a/NuRadioMC/simulation/output_writer_hdf5.py
+++ b/NuRadioMC/simulation/output_writer_hdf5.py
@@ -532,7 +532,9 @@ class outputWriterHDF5:
         Returns:
             float: The calculated effective volume (Veff)
         """
-        # calculate effective volume
+        if not self._mout: # if no events triggered, this is an empty dict
+            return None
+
         triggered = remove_duplicate_triggers(self._mout['triggered'], self._mout['event_group_ids'])
         n_triggered = np.sum(triggered)
         try:


### PR DESCRIPTION
Since the new simulation workflow, the logging output with the number of triggered events and effective volume were not reported for emitter simulations. While the effective volume still does not make sense, this PR makes the logger report the number of triggered events also for emitter simulations, as requested by @ikrav.