### PR TITLE
Fix sign in H_theta in WIPL-D antenna models (introduce createLPDA_100MHz_v2_InfFirn_n1.4)

### DIFF
--- a/NuRadioReco/detector/antenna_models_hash.json
+++ b/NuRadioReco/detector/antenna_models_hash.json
@@ -25,6 +25,8 @@
 	"createLPDA_100MHz_InfAir.pkl": "380f3c36e46bfeacf337bf68923c42cb435712d6",
 	"createLPDA_100MHz_InfFirn.pkl": "75539869378cf145b0735159fb59e1cb86206b6f",
   "createLPDA_100MHz_InfFirn_n1.4.pkl": "44826dc663ec712ca3f642314c688ce52c314387",
+	"createLPDA_100MHz_v2_InfFirn.pkl": "70efa8ef54742057d9d8c3e0045aa469b4214717",
+  "createLPDA_100MHz_v2_InfFirn_n1.4.pkl": "2feedcc4b0fb562a693f450c520d900688267ccc",
   "createLPDA_100MHz_z1cm_InFirn_RG.pkl": "14157207338067dd363153b5ec761694cae483ad",
   "createLPDA_100MHz_z1cm_InFirn_BoresightToBoundary.pkl": "4981d6a0e5f9813493d8a48416f4cd8e2e83259c",
   "createLPDA_100MHz_z10cm_InFirn_RG.pkl": "f9f15fc73b7f34b0eb9f45b485fbb2d0e3d74dd5",

--- a/NuRadioReco/detector/antennapattern.py
+++ b/NuRadioReco/detector/antennapattern.py
@@ -351,7 +351,9 @@ def preprocess_WIPLD_old(path, gen_num=1, s_parameters=None):
     get_Z = interp1d(ff, Z, kind='nearest')
     wavelength = c / ff2
     H_phi = (2 * wavelength * get_Z(ff2) * Iphi) / Z_0 / 1j
-    H_theta = (2 * wavelength * get_Z(ff2) * Itheta) / Z_0 / 1j
+    # need a minus sign in H_theta because eTheta points in the opposite direction
+    # in NuRadio compared to WIPL-D
+    H_theta = -(2 * wavelength * get_Z(ff2) * Itheta) / Z_0 / 1j
 
     return orientation_theta, orientation_phi, rotation_theta, rotation_phi, ff2, theta, phi, H_phi, H_theta
 
@@ -448,16 +450,12 @@ def preprocess_WIPLD(path, gen_num=1, s_parameters=None):
     V = 1 * units.V
     Z_L = 50 * units.ohm
     H_phi = wavelength * (1 + get_S(ff2)) * Iphi * Z_L / Z_0 / 1j / V
-    H_theta = wavelength * (1 + get_S(ff2)) * Itheta * Z_L / Z_0 / 1j / V
+    # need a minus sign in H_theta because eTheta points in the opposite direction
+    # in NuRadio compared to WIPL-D
+    H_theta = -wavelength * (1 + get_S(ff2)) * Itheta * Z_L / Z_0 / 1j / V
 
     #     H = wavelength * (np.real(get_Z(ff2)) / (np.pi * Z_0)) ** 0.5 * gains ** 0.5
     return orientation_theta, orientation_phi, rotation_theta, rotation_phi, ff2, theta, phi, H_phi, H_theta
-
-
-#     output_filename = '{}.pkl'.format(os.path.join(path, name, name))
-#     with open(output_filename, 'wb') as fout:
-#         logger.info('saving output to {}'.format(output_filename))
-#         pickle.dump([orientation_theta, orientation_phi, rotation_theta, rotation_phi, ff2, theta, phi, H_phi, H_theta], fout, protocol=4)
 
 
 def save_preprocessed_WIPLD(path):
@@ -519,7 +517,9 @@ def save_preprocessed_WIPLD_forARA(path):
     get_S = interp1d(ff, S, kind='nearest')
     Gr = gains * (1 - np.abs(get_S(ff2)) ** 2)
     H_phi = wavelength * (1 + get_S(ff2)) * Iphi * Z_L / Z_0 / 1j / V
-    H_theta = wavelength * (1 + get_S(ff2)) * Itheta * Z_L / Z_0 / 1j / V
+    # need a minus sign in H_theta because eTheta points in the opposite direction
+    # in NuRadio compared to WIPL-D
+    H_theta = -wavelength * (1 + get_S(ff2)) * Itheta * Z_L / Z_0 / 1j / V
 
     output_filename = '{}.ara'.format(os.path.join(path, name, name))
     with open(output_filename, 'w') as fout:

--- a/documentation/source/NuRadioReco/pages/detector/antennamodels.rst
+++ b/documentation/source/NuRadioReco/pages/detector/antennamodels.rst
@@ -5,11 +5,11 @@ All antenna models are stored on a central data server and are downloaded automa
 whenever the user requests the antenna model for the first time.
 
 For developers:
-If you add new an antenna model please add the sha1sum = hashlib.sha1() to this list and send Christian
-the antenna model so that he can put it on our central server.
+If you add a new antenna model please add the sha1sum = hashlib.sha1() to ``NuRadioReco/detector/antenna_models_hash.json``
+and send one of the core maintainers the antenna model so that they can put it on our central server.
 
-Implemetation of Antenna Models
-===============================
+Implementation of Antenna Models
+================================
 
 For the antenna orientation and rotation, the conventions are described in :ref:`Properties of Detector Description <NuRadioReco/pages/detector/detector_database_fields:Properties of Detector Description>`
 
@@ -57,6 +57,7 @@ WIPL-D simulation of ARA Bicone antenna.
 This antenna has been used by ARIANNA at the South Pole.
 The antenna is embedded in an infinite medium with an index of refraction of n = 1.0.
 The complex (magnitude + phase) vector effective length of both polarization components (ePhi, eTheta) is provided.
+
 Theta range [-90,90] Phi range [0,360] Freq range [5,1000]MHz
 
 Last updated: 2018
@@ -70,6 +71,7 @@ WIPL-D simulation of ARA Bicone antenna.
 This antenna has been used by ARIANNA at the South Pole.
 The antenna is embedded in an infinite medium with an index of refraction of n = 1.32.
 The complex (magnitude + phase) vector effective length of both polarization components (ePhi, eTheta) is provided.
+
 Theta range [-90,90] Phi range [0,360] Freq range [5,1000]MHz
 
 Last updated: 2018
@@ -80,6 +82,7 @@ WIPL-D simulation of ARA Bicone antenna.
 This antenna has been used by ARIANNA at the South Pole.
 The antenna is embedded in an infinite medium with an index of refraction of n = 1.4.
 The complex (magnitude + phase) vector effective length of both polarization components (ePhi, eTheta) is provided.
+
 Theta range [-90,90] Phi range [0,360] Freq range [5,1000]MHz
 
 Last updated: 2018
@@ -90,6 +93,7 @@ WIPL-D simulation of ARA Bicone antenna.
 This antenna has been used by ARIANNA at the South Pole.
 The antenna is embedded in an infinite medium with an index of refraction of n = 1.78.
 The complex (magnitude + phase) vector effective length of both polarization components (ePhi, eTheta) is provided.
+
 Theta range [-90,90] Phi range [0,360] Freq range [5,1000]MHz
 
 Last updated: 2018
@@ -152,6 +156,7 @@ WIPL-D simulation of 100 MHz LPDA from create.
 This antenna is used by ARIANNA.
 lowest/largest tine 1cm above air (this is because in the simulation the geometry is inverted, the ground is air and the medium of the antenna is firn).
 The complex (magnitude + phase) vector effective length of both polarization components (ePhi, eTheta) is provided.
+
 Theta range [0,90] Phi range [0,360] Freq range [5,1000]MHz
 
 Last updated: 2018
@@ -162,6 +167,7 @@ WIPL-D simulation of 100 MHz LPDA from create.
 This antenna is used by ARIANNA.
 smallest/highest tine 1cm below air.
 The complex (magnitude + phase) vector effective length of both polarization components (ePhi, eTheta) is provided.
+
 Theta range [0,90] Phi range [0,360] Freq range [20,1000]MHz
 
 Last updated: 2018
@@ -172,6 +178,7 @@ WIPL-D simulation of 100 MHz LPDA from create.
 This antenna is used by ARIANNA.
 lowest/largest tine 10cm above air.
 The complex (magnitude + phase) vector effective length of both polarization components (ePhi, eTheta) is provided.
+
 Theta range [0,90] Phi range [0,360] Freq range [5,1000]MHz
 
 Last updated: 2018
@@ -182,6 +189,7 @@ WIPL-D simulation of 100 MHz LPDA from create.
 This antenna is used by ARIANNA.
 lowest/largest tine 1m above air.
 The complex (magnitude + phase) vector effective length of both polarization components (ePhi, eTheta) is provided.
+
 Theta range [0,90] Phi range [0,360] Freq range [5,1000]MHz
 
 Last updated: 2018
@@ -191,6 +199,7 @@ createLPDA_100MHz_z2m_InFirn_RG
 WIPL-D simulation of 100 MHz LPDA from create.
 This antenna is used by ARIANNA. Largest tine 2m above air.
 The complex (magnitude + phase) vector effective length of both polarization components (ePhi, eTheta) is provided.
+
 Theta range [0,90] Phi range [0,360] Freq range [5,1000]MHz
 
 Last updated: 2018
@@ -200,6 +209,7 @@ createLPDA_100MHz_z2m_InFirn_Backlobe_NoRG
 WIPL-D simulation of 100 MHz LPDA from create.
 This antenna is used by ARIANNA. Largest tine 2m above air.
 The complex (magnitude + phase) vector effective length of both polarization components (ePhi, eTheta) is provided.
+
 Theta range [0,90] Phi range [0,360] Freq range [200,1000]MHz
 
 Last updated: 2018
@@ -209,6 +219,7 @@ createLPDA_100MHz_z3m_InAir_RG
 WIPL-D simulation of 100 MHz LPDA from create.
 This antenna is used by ARIANNA. lowest/largest tine 3m above firn.
 The complex (magnitude + phase) vector effective length of both polarization components (ePhi, eTheta) is provided.
+
 Theta range [0,90] Phi range [0,360] Freq range [5,1000]MHz
 
 Last updated: 2018
@@ -219,6 +230,7 @@ WIPL-D simulation of 100 MHz LPDA from create.
 This antenna is used by ARIANNA.
 Largest tine 3m below air; nose 1.58m below air.
 The complex (magnitude + phase) vector effective length of both polarization components (ePhi, eTheta) is provided.
+
 Theta range [0,90] Phi range [0,360] Freq range [20,1000]MHz
 
 Last updated: 2018
@@ -228,6 +240,7 @@ createLPDA_100MHz_z3mAndLPDALen_InFirn_BoresightToBoundary
 WIPL-D simulation of 100 MHz LPDA from create.
 This antenna is used by ARIANNA. Nose 3.2m below air.
 The complex (magnitude + phase) vector effective length of both polarization components (ePhi, eTheta) is provided.
+
 Theta range [0,90] Phi range [0,360] Freq range [5,1000]MHz
 
 Last updated: 2018
@@ -237,6 +250,7 @@ createLPDA_100MHz_z5m_InFirn_RG
 WIPL-D simulation of 100 MHz LPDA from create. This antenna is used by ARIANNA.
 Largest tine 5m above air.
 The complex (magnitude + phase) vector effective length of both polarization components (ePhi, eTheta) is provided.
+
 Theta range [0,90] Phi range [0,360] Freq range [5,1000]MHz
 
 Last updated: 2018
@@ -247,6 +261,7 @@ WIPL-D simulation of 100 MHz LPDA from create.
 This antenna is used by ARIANNA.
 Largest tine 10m above air.
 The complex (magnitude + phase) vector effective length of both polarization components (ePhi, eTheta) is provided.
+
 Theta range [0,90] Phi range [0,360] Freq range [5,1000]MHz
 
 Last updated: 2018
@@ -256,6 +271,7 @@ createLPDA_100MHz_z100m_InFirn_RG
 WIPL-D simulation of 100 MHz LPDA from create.
 This antenna is used by ARIANNA. Largest tine 100m above air.
 The complex (magnitude + phase) vector effective length of both polarization components (ePhi, eTheta) is provided.
+
 Theta range [0,90] Phi range [0,360] Freq range [5,1000]MHz
 
 Last updated: 2018
@@ -265,6 +281,7 @@ createLPDA_100MHz_z200m_InFirn_RG
 WIPL-D simulation of 100 MHz LPDA from create.
 This antenna is used by ARIANNA. Largest tine 200m above air.
 The complex (magnitude + phase) vector effective length of both polarization components (ePhi, eTheta) is provided.
+
 Theta range [0,90] Phi range [0,360] Freq range [5,1000]MHz
 
 Last updated: 2018
@@ -272,6 +289,7 @@ Last updated: 2018
 createLPDA_100MHz_InfAir
 -------------------------
 Same as createLPDA_100MHz_InfFirn but antenna embedded in infinite air (i.e. n = 1).
+
 Theta range [-90,90] Phi range [0,360] Freq range [5,1000]MHz
 
 Last updated: 2018
@@ -282,6 +300,7 @@ WIPL-D simulation of 100 MHz LPDA from create.
 This antenna is used by ARIANNA.
 lowest/largest tine 1cm above firn (this is because in the simulation the geometry is inverted, the ground is air and the medium of the antenna is firn).
 The complex (magnitude + phase) vector effective length of both polarization components (ePhi, eTheta) is provided.
+
 Theta range [0,90] Phi range [0,360] Freq range [5,1000]MHz
 
 Last updated: 2018
@@ -295,6 +314,7 @@ WIPL-D simulation of KU dipole 52cm long.
 This antenna is used by ARIANNA.
 Horizontally orientated dipole antenna in infinite firn media(n=1.3 assumed).
 The complex (magnitude + phase) vector effective length of both polarization components (ePhi, eTheta) is provided.
+
 Theta range [0,90] Phi range [0,360] Freq range [20,1000]MHz
 
 Last updated: 2018
@@ -304,6 +324,7 @@ dip7cm_z260mm_InFirn_RG
 WIPL-D simulation of KU dipole 52cm long.
 This antenna is used by ARIANNA. dipole center 260cm in firn.
 The complex (magnitude + phase) vector effective length of both polarization components (ePhi, eTheta) is provided.
+
 Theta range [0,90] Phi range [0,360] Freq range [20,1000]MHz
 
 Last updated: 2018
@@ -313,6 +334,7 @@ dip7cm_z1m_InFirn_RG
 WIPL-D simulation of KU dipole 52cm long.
 This antenna is used by ARIANNA. dipole center 1m in firn.
 The complex (magnitude + phase) vector effective length of both polarization components (ePhi, eTheta) is provided.
+
 Theta range [0,90] Phi range [0,360] Freq range [20,1000]MHz
 
 Last updated: 2018
@@ -322,6 +344,7 @@ dip7cm_z2m_InFirn_RG
 WIPL-D simulation of KU dipole 52cm long.
 This antenna is used by ARIANNA. dipole center 2m in firn.
 The complex (magnitude + phase) vector effective length of both polarization components (ePhi, eTheta) is provided.
+
 Theta range [0,90] Phi range [0,360] Freq range [20,1000]MHz
 
 Last updated: 2018
@@ -331,6 +354,7 @@ dip7cm_z3m_InFirn_RG_NearHorizontalHD
 WIPL-D simulation of KU dipole 52cm long.
 This antenna is used by ARIANNA. dipole center 3m in firn.
 The complex (magnitude + phase) vector effective length of both polarization components (ePhi, eTheta) is provided.
+
 Theta range [0,0.5] Phi range [0,360] Freq range [20,1000]MHz
 
 Last updated: 2018
@@ -340,6 +364,7 @@ dip7cm_z5m_InFirn_RG
 WIPL-D simulation of KU dipole 52cm long.
 This antenna is used by ARIANNA. dipole center 5m above air.
 The complex (magnitude + phase) vector effective length of both polarization components (ePhi, eTheta) is provided.
+
 Theta range [0,90] Phi range [0,360] Freq range [20,1000]MHz
 
 Last updated: 2018
@@ -349,6 +374,7 @@ dip7cm_z10m_InFirn_RG
 WIPL-D simulation of KU dipole 52cm long.
 This antenna is used by ARIANNA. dipole center 10m above air.
 The complex (magnitude + phase) vector effective length of both polarization components (ePhi, eTheta) is provided.
+
 Theta range [0,90] Phi range [0,360] Freq range [20,1000]MHz
 
 Last updated: 2018
@@ -359,6 +385,7 @@ WIPL-D simulation of KU dipole 52cm long.
 This antenna is used by ARIANNA.
 Dipole center 200m below surface.
 The complex (magnitude + phase) vector effective length of both polarization components (ePhi, eTheta) is provided.
+
 Theta range [0,90] Phi range [0,360] Freq range [20,1000]MHz
 
 Last updated: 2018
@@ -368,6 +395,7 @@ dip7cm_z100m_InFirn_RG
 WIPL-D simulation of KU dipole 52cm long.
 This antenna is used by ARIANNA. dipole center 100m below surface.
 The complex (magnitude + phase) vector effective length of both polarization components (ePhi, eTheta) is provided.
+
 Theta range [0,90] Phi range [0,360] Freq range [20,1000]MHz
 
 Last updated: 2018
@@ -378,6 +406,7 @@ dip7cm_infAir_s12
 WIPL-D simulation of KU dipole 52cm long. This antenna is used by ARIANNA.
 Vertically orientated dipole in infinite air (n=1).
 The complex (magnitude + phase) vector effective length of both polarization components (ePhi, eTheta) is provided.
+
 Theta range [=90,90] Phi range [0,360] Freq range [20,1000]MHz
 
 Last updated: 2018
@@ -387,6 +416,7 @@ dip7cm_z270mm_InAir
 WIPL-D simulation of KU dipole 52cm long.
 This antenna is used by ARIANNA. dipole center 270mm deep, in infinite air (n=1).
 The complex (magnitude + phase) vector effective length of both polarization components (ePhi, eTheta) is provided.
+
 Theta range [0,90] Phi range [0,360] Freq range [20,1000]MHz
 
 Last updated: 2018
@@ -396,6 +426,7 @@ dip7cm_z1m_InAir
 WIPL-D simulation of KU dipole 52cm long.
 This antenna is used by ARIANNA. dipole center 1m above firn.
 The complex (magnitude + phase) vector effective length of both polarization components (ePhi, eTheta) is provided.
+
 Theta range [0,90] Phi range [0,360] Freq range [20,1000]MHz
 
 Last updated: 2018
@@ -405,6 +436,7 @@ dip7cm_z1m_InAir_RG_NearHorizontalHD
 WIPL-D simulation of KU dipole 52cm long.
 This antenna is used by ARIANNA. dipole center 1m above air.
 The complex (magnitude + phase) vector effective length of both polarization components (ePhi, eTheta) is provided.
+
 Theta range [0,1] Phi range [0,360] Freq range [20,1000]MHz
 
 Last updated: 2018
@@ -414,6 +446,7 @@ dip7cm_z1m_InAir_RG_NearHorizontalHD2
 WIPL-D simulation of KU dipole 52cm long.
 This antenna is used by ARIANNA. dipole center 1m above air.
 The complex (magnitude + phase) vector effective length of both polarization components (ePhi, eTheta) is provided.
+
 Theta range [0,0.5] Phi range [0,360] Freq range [20,1000]MHz
 
 Last updated: 2018
@@ -423,6 +456,7 @@ dip7cm_z2m_InAir
 WIPL-D simulation of KU dipole 52cm long.
 This antenna is used by ARIANNA. dipole center 2m above firn.
 The complex (magnitude + phase) vector effective length of both polarization components (ePhi, eTheta) is provided.
+
 Theta range [0,90] Phi range [0,360] Freq range [20,1000]MHz
 
 Last updated: 2018
@@ -433,6 +467,7 @@ dip7cm_z5m_InAir
 WIPL-D simulation of KU dipole 52cm long.
 This antenna is used by ARIANNA. dipole center 5m above firn.
 The complex (magnitude + phase) vector effective length of both polarization components (ePhi, eTheta) is provided.
+
 Theta range [0,90] Phi range [0,360] Freq range [20,1000]MHz
 
 Last updated: 2018
@@ -441,6 +476,7 @@ RNOG_vpol_4inch_center_n1.73
 -----------------------------
 xF simulations for the RNOG Vpol in a 5.75 inch borehole with index of refraction of ice n=1.73.
 The antenna is placed in the center (x, y) of the borehole. An extra cubic interpolation is performed in frequencies (5 MHz step).
+
 Theta range [0, 90] Phi range [0, 360] Freq range [0, 4200]MHz
 
 Last updated: 2020
@@ -449,6 +485,7 @@ RNOG_vpol_4inch_half_n1.73
 ---------------------------
 xF simulations for the RNOG Vpol in a 5.75 inch borehole with index of refraction of ice n=1.73.
 The antenna is halfway displaced from the center towards phi = 0. An extra cubic interpolation is performed in frequencies (5 MHz step).
+
 Theta range [0, 90] Phi range [0, 360] Freq range [0, 4200]MHz
 
 Last updated: 2020
@@ -457,13 +494,16 @@ RNOG_vpol_4inch_wall_n1.73
 ---------------------------
 xF simulations for the RNOG Vpol in a 5.75 inch borehole with index of refraction of ice n=1.73.
 The antenna placed against the wall towards phi = 0. An extra cubic interpolation is performed in frequencies (5 MHz step).
+
 Theta range [0, 90] Phi range [0, 360] Freq range [0, 4200]MHz
 
 Last updated: 2020
 
 RNOG_vpol_v3_5inch_center_n1.74
 -------------------------------
-XFdtd simulations for the RNO-G VPol in an 11.2 inch diameter borehole with index of refraction of ice n=1.74. The antenna is placed in the center (x, y) of the borehole. Theta range [0, 180] Phi range [0, 360] Freq range [0, 1000]MHz. No power feed-through cable included.
+XFdtd simulations for the RNO-G VPol in an 11.2 inch diameter borehole with index of refraction of ice n=1.74. The antenna is placed in the center (x, y) of the borehole.
+
+Theta range [0, 180] Phi range [0, 360] Freq range [0, 1000]MHz. No power feed-through cable included.
 
 Note: Simulation ran with Theta range [0, 90] and Phi range [0, 90] due to simulation size constraints and was extended to range noted above using symmetry.
 
@@ -471,7 +511,9 @@ Last updated: 2025
 
 RNOG_hpol_v4_8inch_center_n1.74
 -------------------------------
-XFdtd simulations for the RNO-G HPol in an 11.2 inch diameter borehole with index of refraction of ice n=1.74. The antenna is placed in the center (x, y) of the borehole. Theta range [0, 180] Phi range [0, 360] Freq range [0, 1000]MHz. No power feed-through cable included.
+XFdtd simulations for the RNO-G HPol in an 11.2 inch diameter borehole with index of refraction of ice n=1.74. The antenna is placed in the center (x, y) of the borehole.
+
+Theta range [0, 180] Phi range [0, 360] Freq range [0, 1000]MHz. No power feed-through cable included.
 
 Note: Simulation ran with Theta range [0, 90] and Phi range [0, 90] due to simulation size constraints and was extended to range noted above using symmetry.
 
@@ -481,6 +523,7 @@ RNOG_quadslot_v1_n1.74
 -----------------------
 XFdtd simulations for the RNOG Hpol.
 Simulations are done in air, frequencies are rescaled with n=1.74. An extra cubic interpolation is performed in frequencies (5 MHz step).
+
 Theta range [-180, 180] Phi range [0, 360] Freq range [57, 574]MHz
 
 Last updated: 2020
@@ -489,6 +532,7 @@ RNOG_quadslot_v2_n1.74
 -----------------------
 XFdtd simulations for the RNOG Hpol.
 Simulations are done in air, frequencies are rescaled with n=1.74. An extra cubic interpolation is performed in frequencies (5 MHz step).
+
 Theta range [-180, 180] Phi range [0, 360] Freq range [57, 574]MHz
 
 Last updated: 2020
@@ -500,6 +544,7 @@ RNOG_quadslot_v3_air_rescaled_to_n1.74
 ---------------------------------------
 XFdtd simulations in for the RNO-G Hpol.
 Simulations are done in air, frequencies are rescaled with n=1.74.
+
 Theta range [-180, 180] Phi range [0, 360] Freq range [57, 574]MHz
 
 Last updated: 2020
@@ -508,8 +553,11 @@ SKALA_InfFirn
 --------------
 Log-periodic antenna for SKA-low, called SKALA-2.
 The complex (magnitude + phase) vector effective length of both polarization components (ePhi, eTheta) is provided.
+
 Theta range [0, 90]; Phi range [0, 360]; Freq range [50, 350]MHz
+
 For more information, see: https://ieeexplore.ieee.org/abstract/document/7297231/authors#authors
+
 Last updated: 2021
 
 SmallBlackSpider_ground2_measured

--- a/documentation/source/NuRadioReco/pages/detector/antennamodels.rst
+++ b/documentation/source/NuRadioReco/pages/detector/antennamodels.rst
@@ -13,7 +13,8 @@ Implemetation of Antenna Models
 
 For the antenna orientation and rotation, the conventions are described in :ref:`Properties of Detector Description <NuRadioReco/pages/detector/detector_database_fields:Properties of Detector Description>`
 
-The antenna models are accessed in the `AntennaPattern` class in the `nuradioreco.detector.antennapattern.py` module.
+The antenna models are accessed in the `AntennaPattern <NuRadioReco.detector.antennapattern.AntennaPattern>`
+class in the `NuRadioReco.detector.antennapattern <NuRadioReco.detector.antennapattern>` module.
 Different software packages are used to simulate the antennas, internally, NuRadioReco converts the data to a common pickle format in which they are
 stored.
 
@@ -95,20 +96,55 @@ Last updated: 2018
 
 createLPDA_100MHz_InfFirn
 --------------------------
+.. warning::
+    This model has the wrong sign for the eTheta component;
+    this has been corrected in the :ref:`createLPDA_100MHz_v2_InfFirn <NuRadioReco/pages/detector/antennamodels:createLPDA_100MHz_v2_InfFirn>` model,
+    which therefore supersedes this version.
+
 WIPL-D simulation of 100 MHz LPDA from create.
 This antenna is used by ARIANNA.
 The antenna is embedded in an infinite medium with an index of refraction of n = 1.3.
 The complex (magnitude + phase) vector effective length of both polarization components (ePhi, eTheta) is provided.
+
 Theta range [-90,90] Phi range [0,360] Freq range [5,1000]MHz assumed
 
 Last updated: 2018
 
-createLPDA_InfFirn_n1.4
-------------------------
+createLPDA_100MHz_v2_InfFirn
+----------------------------
+WIPL-D simulation of 100 MHz LPDA from create. The ``v2`` version differs
+only by a relative minus sign in the ``eTheta`` component; in the older version
+the wrong sign was used.
+This antenna is used by ARIANNA.
+The antenna is embedded in an infinite medium with an index of refraction of n = 1.3.
+The complex (magnitude + phase) vector effective length of both polarization components (ePhi, eTheta) is provided.
+
+Theta range [-90,90] Phi range [0,360] Freq range [5,1000] MHz assumed
+
+Last updated: 2025
+
+createLPDA_100MHz_InfFirn_n1.4
+------------------------------
+.. warning::
+    This model has the wrong sign for the eTheta component;
+    this has been corrected in the :ref:`createLPDA_100MHz_v2_InfFirn_n1.4 <NuRadioReco/pages/detector/antennamodels:createLPDA_100MHz_v2_InfFirn_n1.4>` model,
+    which therefore supersedes this version.
+
 Same as createLPDA_100MHz_InfFirn but antenna embedded in infinite firn with index of n = 1.4.
+
 Theta range [-90,90] Phi range [0,360] Freq range [5,1000]MHz
 
 Last updated: 2018
+
+createLPDA_100MHz_v2_InfFirn_n1.4
+---------------------------------
+Same as createLPDA_100MHz_v2_InfFirn but antenna embedded in infinite firn with index of n = 1.4.
+The ``v2`` version differs only by a relative minus sign in the ``eTheta`` component;
+in the older version the wrong sign was used.
+
+Theta range [-90,90] Phi range [0,360] Freq range [5,1000]MHz
+
+Last updated: 2025
 
 createLPDA_100MHz_z1cm_InFirn_RG
 ---------------------------------


### PR DESCRIPTION
After a very long time spent debugging cosmic-ray polarizations, I found an issue with the WIPL-D antenna models in NuRadio. Because zenith `theta` is defined to go from `90 -> -90` degrees from the positive to the negative z-axis in WIPL-D, instead of `0 -> 180` degrees in NuRadio, in addition to the conversion of the zenith, there is also a minus sign when converting the theta-component of the vector effective length `H_theta`. This sign had so far been missing. 

I have updated the `preprocess_WIPLD` functions to include this sign, and corrected it for the `createLPDA_100MHz_InfFirn` and `createLPDA_100MHz_InfFirn_n1.4` antenna models in the new `createLPDA_100MHz_v2_InfFirn` and `createLPDA_100MHz_v2_InfFirn_n1.4` models, respectively. If requested I can correct the other WIPL-D models as well.

The effect of this sign mistake is to swap polarization angles of `x` degrees with angles of `180-x` degrees. This is **not** negligible for incoming electric fields which are not purely theta- or phi-polarized and antenna responses where both the sensitivities to both components are non-negligible. Here's a simple example plot for a realistic parameterized cosmic ray signal demonstrating this (the blue pulse is for the old antenna model, orange shows the updated one)
<img width="549" height="406" alt="image" src="https://github.com/user-attachments/assets/93823e86-49ec-4bf1-8da1-e929d008344a" />

However, this sign mistake does **not** affect previous ARIANNA analyses, as far as I am aware, which have usually defined the polarization angle from the electric field fluences in theta and phi, which are always positive and hence not sensitive to a sign in theta or phi. Neither is it expected to affect the overall expectation for the cosmic-ray trigger rate significantly. However, the distribution as a function of incoming azimuth **will** change.

There is one more cross-check one can do: naively one expects the theta and phi components to contribute coherently to the measured signal if their projections onto the antenna tine direction point in parallel directions, and interfere destructively if they point in opposite directions. This plot shows the relative phases of the theta and phi components as a function of incoming direction for an upward-pointing LPDA with its tines aligned along the x-axis, using the **old** antenna model.
<img width="720" height="329" alt="image" src="https://github.com/user-attachments/assets/250f61ed-e610-45f4-a2ff-d74d4f4d64aa" />

In the NuRadio convention, at an azimuth of 45 degrees, the x-component of eTheta is positive, but the x-component of ePhi is negative, so one would expect a phase difference between the two components of ~180 degrees, with the situation reversed for an azimuth of 135 degrees. This is indeed the **opposite** of what is shown for the old antenna model above, and correct for the new antenna models.
