### PR TITLE
Fail with an informative error message when cpp raytracer is not avai…

### DIFF
--- a/NuRadioMC/SignalProp/analyticraytracing.py
+++ b/NuRadioMC/SignalProp/analyticraytracing.py
@@ -418,7 +418,7 @@ class ray_tracing_2D(ray_tracing_base):
                 self.__logger.info('Using C++ raytracer')
         else:
             if use_cpp:
-				msg = ('C++ raytracer was explicitly requested, but is not available (i.e. on-the-fly compilation failed). '
+                msg = ('C++ raytracer was explicitly requested, but is not available (i.e. on-the-fly compilation failed). '
 					   'Abort.... ! Either fix the compilation or set use_cpp to False. '
 					   'For compilation see NuRadioMC/SignalProp/install.sh resp. NuRadioMC/SignalProp/CPPAnalyticRayTracing.')
                 self.__logger.error(msg)


### PR DESCRIPTION
It seems this is not the intended behavior.

- either loudly fall back to python raytracer if cpp does not compile
- or fail with an informative error msg

I choose the latter.