### PR TITLE
make both dateimetimes compatible

### DIFF
--- a/NuRadioReco/detector/RNO_G/db_mongo_read.py
+++ b/NuRadioReco/detector/RNO_G/db_mongo_read.py
@@ -21,7 +21,6 @@ import numpy as np
 from functools import wraps
 import copy
 import re
-import warnings
 
 from pymongo import MongoClient
 import NuRadioReco.utilities.metaclasses
@@ -161,7 +160,7 @@ class Database(object):
             raise TypeError("Set invalid time for database. Time has to be of type datetime.datetime")
 
         if time.tzinfo is None:
-            warnings.warn("No timezone information provided. Assuming UTC.")
+            logger.warning(f"No timezone information provided for the database time {time}. Assuming UTC.")
             time = time.replace(tzinfo=datetime.timezone.utc)
 
         if time < datetime.datetime(2024, 11, 1, tzinfo=datetime.timezone.utc):


### PR DESCRIPTION
Issue being addressed: UTC time mismatch between db_mongo_read.py and db_mongo_write.py #1001 