### PR TITLE
Unpin pygdsm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,10 +47,7 @@ sphinx-rtd-theme = {version = "*", optional = true}
 numpydoc = {version = "*", optional = true}
 proposal = {version = "7.6.2", optional = true}
 pylfmap = {version = "*", optional = true}
-pygdsm = [
-    {version = "<=1.6.0", python = "<3.10", optional = true},
-    {version = "*", python = ">=3.10", optional = true}
-]
+pygdsm = {version = "*", optional = true}
 healpy = {version = "*", optional = true}
 MCEq = {version = "*", optional = true}
 crflux = {version = "*", optional = true}


### PR DESCRIPTION
pygdsm 1.6.4 (the latest release) is compatible with python >= 3.7 again, so we can unpin it. In fact the old 'fix' did not work because the pinned version (1.6.0) already included some typing that was not compatible with older versions.

As long as future pygdsm versions deprecate older python versions in the requirements (or stay compatible) we will not need to re-pin in the future (otherwise, we can simply pin it again).