### PR TITLE
Do not cancel in-progress unit tests with different python / os version

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -29,7 +29,7 @@ env: # set the python_version to 3.10 if the workflow is not triggered by workfl
   PYTHON_VERSION: ${{ inputs.python_version || '3.10' }}
 
 concurrency: # run only one instance of the tests per branch
-  group: unit-tests-${{ github.ref }}
+  group: unit-tests-${{ inputs.os || 'ubuntu-latest' }}-${{ inputs.python_version || '3.10' }}-${{ github.ref }}
   cancel-in-progress: true # cancel currently running checks on a new push
 
 jobs:


### PR DESCRIPTION
I left in the concurrency feature, because I thought it doesn't harm to cancel in-progress tests if a more recent push has been made... turns out it did harm, because it also cancelled in-progress tests running on different python version, such as in the python version compatibility checks on `develop`. This should be fixed now.

@fschlueter let me know if you would prefer to remove this altogether.