### PR TITLE
add missing declination argument in read_CORSIKA7

### DIFF
--- a/NuRadioReco/modules/io/coreas/coreas.py
+++ b/NuRadioReco/modules/io/coreas/coreas.py
@@ -93,7 +93,7 @@ def get_angles(corsika, declination):
     """
     zenith = corsika['inputs'].attrs["THETAP"][0] * units.deg
     azimuth = hp.get_normalized_angle(
-        3 * np.pi / 2. + np.deg2rad(corsika['inputs'].attrs["PHIP"][0]) + declination / units.rad
+        3 * np.pi / 2. + np.deg2rad(corsika['inputs'].attrs["PHIP"][0]) - declination / units.rad
     ) * units.rad
 
     # in CORSIKA convention, the first component points North (y in NRR) and the second component points down (minus z)


### PR DESCRIPTION
When reading in CORSIKA7 files, the 'sim_shower' created would always have the magnetic field declination set to 0, even though the site declination (if available through radiotools) was used for the electric field positions. This would lead to inconsistencies e.g. in the coreasInterpolator, which uses the magnetic field stored in the sim shower to convert between on-ground and vxB/vxvxB coordinates.

This PR fixes this by using the same declination between the electric fields and the sim shower. 

(Note that there's still some ambiguity introduced by the fact that we take the magnetic field **inclination** from CORSIKA but use the **declination** from radiotools, but a better solution is not immediately obvious to me. In any case the magnetic field vector is now stored consistently in the sim shower object.)