### PR TITLE
Avoiding incomplete export of RNOG detector descriptions.

### DIFF
--- a/NuRadioReco/detector/RNO_G/rnog_detector.py
+++ b/NuRadioReco/detector/RNO_G/rnog_detector.py
@@ -242,6 +242,13 @@ class Detector():
             An optional comment describing this detector that will be added to the exported detector description.
         """
 
+        if not self._query_all:
+            self.logger.error(
+                "You are exporting the detector description but you have not queried the entire description at once. "
+                "This means that only the currently buffered station description is exported which is potentially "
+                "incomplete. If you want to export the entire description, set `always_query_entire_description=True` "
+                "in the constructor before exporting.")
+
         periods = {}
         for station_id in self.__buffered_stations:
 

--- a/NuRadioReco/detector/RNO_G/rnog_detector.py
+++ b/NuRadioReco/detector/RNO_G/rnog_detector.py
@@ -246,11 +246,11 @@ class Detector():
             # When not querying the entire description at once,
             # we need to make sure that the buffer is updated
             # for all stations before exporting.
-            self._query_all = True
+            self.logger.info("Query entire detector description at once before exporting (this might take a while) ...")
             for station_id in self.__buffered_stations:
                 # remove everything (could be handled smarter ...)
                 self.__buffered_stations[station_id] = {}
-                self._query_station_information(station_id)
+                self._query_station_information(station_id, all=True)
 
         periods = {}
         for station_id in self.__buffered_stations:
@@ -507,7 +507,7 @@ class Detector():
 
             for station_id, need_update in update_buffer_for_station.items():
                 if need_update and self.has_station(station_id):
-                    self._query_station_information(station_id)
+                    self._query_station_information(station_id, all=self._query_all)
 
         # Return when buffer is not empty. This has to come first ...
         for station_id in self.__buffered_stations:
@@ -578,7 +578,7 @@ class Detector():
         self.logger.debug(f"Station {station_id} not commissioned!")
         return False
 
-    def _query_station_information(self, station_id):
+    def _query_station_information(self, station_id, all):
         """
         Query information about a specific station from the database via the db_mongo_read interface.
         You can query only information from the station_list collection (all=False) or the complete
@@ -601,7 +601,8 @@ class Detector():
 
         self.logger.info(
             f"Query information for station {station_id} at {self.get_detector_time()}")
-        if self._query_all:
+
+        if all:
             station_information = self.__db.get_complete_station_information(
                 station_id, measurement_signal_chain=self.signal_chain_measurement_name)
         else:

--- a/NuRadioReco/detector/RNO_G/rnog_detector.py
+++ b/NuRadioReco/detector/RNO_G/rnog_detector.py
@@ -250,7 +250,7 @@ class Detector():
             for station_id in self.__buffered_stations:
                 # remove everything (could be handled smarter ...)
                 self.__buffered_stations[station_id] = {}
-                self._query_station_information(station_id, all=True)
+                self._query_station_information(station_id, query_all_information=True)
 
         periods = {}
         for station_id in self.__buffered_stations:
@@ -507,7 +507,7 @@ class Detector():
 
             for station_id, need_update in update_buffer_for_station.items():
                 if need_update and self.has_station(station_id):
-                    self._query_station_information(station_id, all=self._query_all)
+                    self._query_station_information(station_id, query_all_information=self._query_all)
 
         # Return when buffer is not empty. This has to come first ...
         for station_id in self.__buffered_stations:
@@ -578,18 +578,18 @@ class Detector():
         self.logger.debug(f"Station {station_id} not commissioned!")
         return False
 
-    def _query_station_information(self, station_id, all):
+    def _query_station_information(self, station_id, query_all_information):
         """
         Query information about a specific station from the database via the db_mongo_read interface.
-        You can query only information from the station_list collection (all=False) or the complete
-        information of the station (all=True).
+        You can query only information from the station_list collection (query_all_information=False) 
+        or the complete information of the station (query_all_information=True).
 
         Parameters
         ----------
         station_id: int
             Station id
 
-        all: bool
+        query_all_information: bool
             If true, query all relevant information form a station including its channel and devices (position, signal chain, ...).
             If false, query only the information from the station list collection (describes a station with all channels and devices
             with their (de)commissioning timestamps but not data like position, signal chain, ...)
@@ -602,7 +602,7 @@ class Detector():
         self.logger.info(
             f"Query information for station {station_id} at {self.get_detector_time()}")
 
-        if all:
+        if query_all_information:
             station_information = self.__db.get_complete_station_information(
                 station_id, measurement_signal_chain=self.signal_chain_measurement_name)
         else:

--- a/NuRadioReco/detector/RNO_G/rnog_detector.py
+++ b/NuRadioReco/detector/RNO_G/rnog_detector.py
@@ -246,6 +246,7 @@ class Detector():
             # When not querying the entire description at once,
             # we need to make sure that the buffer is updated
             # for all stations before exporting.
+            self._query_all = True
             for station_id in self.__buffered_stations:
                 # remove everything (could be handled smarter ...)
                 self.__buffered_stations[station_id] = {}

--- a/NuRadioReco/detector/RNO_G/rnog_detector.py
+++ b/NuRadioReco/detector/RNO_G/rnog_detector.py
@@ -243,11 +243,13 @@ class Detector():
         """
 
         if not self._query_all:
-            self.logger.error(
-                "You are exporting the detector description but you have not queried the entire description at once. "
-                "This means that only the currently buffered station description is exported which is potentially "
-                "incomplete. If you want to export the entire description, set `always_query_entire_description=True` "
-                "in the constructor before exporting.")
+            # When not querying the entire description at once,
+            # we need to make sure that the buffer is updated
+            # for all stations before exporting.
+            for station_id in self.__buffered_stations:
+                # remove everything (could be handled smarter ...)
+                self.__buffered_stations[station_id] = {}
+                self._query_station_information(station_id)
 
         periods = {}
         for station_id in self.__buffered_stations:

--- a/NuRadioReco/detector/test/test_rnog_detector.py
+++ b/NuRadioReco/detector/test/test_rnog_detector.py
@@ -3,24 +3,47 @@ from NuRadioReco.framework import electric_field
 import logging
 import datetime
 import numpy as np
+import os
 
 
-def test_detector():
+def test_detector(always_query_entire_description=True, cleanup=True):
+    test_filepath = os.path.join(
+        os.path.dirname(__file__), 'test-rnog-detector.json.xz')
 
-    det = detector.Detector(source="rnog_mongo", log_level=logging.DEBUG, always_query_entire_description=True,
-                            database_connection='RNOG_public', select_stations=24)
+    det = detector.Detector(
+        source="rnog_mongo", log_level=logging.DEBUG,
+        always_query_entire_description=always_query_entire_description,
+        database_connection='RNOG_public', select_stations=24)
     det.update(datetime.datetime(2023, 8, 2, 0, 0))
-    det.export("station24.json.xz")
-
-    det2 = detector.Detector(source="rnog_mongo", detector_file="station24.json.xz", select_stations=24)
-    det2.update(datetime.datetime(2023, 8, 2, 0, 0))
-
     response = det.get_signal_chain_response(24, 0)
 
-    ef = electric_field.ElectricField(channel_ids=[0])
-    ef.set_frequency_spectrum(np.ones(1025, dtype=complex), sampling_rate=2.4)
+    det.export(test_filepath)
 
-    ef *= response
+    # test detector loaded from json
+    det_from_file = detector.Detector(
+        source="rnog_mongo", detector_file=test_filepath,
+        select_stations=24, create_new=True)
+    det_from_file.update(datetime.datetime(2023, 8, 2, 0, 0))
+
+    response_from_file = det_from_file.get_signal_chain_response(24, 0)
+
+    efields = []
+    for i in range(2):
+        ef = electric_field.ElectricField(channel_ids=[0])
+        ef.set_frequency_spectrum(np.ones(1025, dtype=complex), sampling_rate=2.4)
+        efields.append(ef)
+
+    ef_from_db = efields[0] * response
+    ef_from_file = efields[1] * response_from_file
+
+    assert np.allclose(
+        ef_from_db.get_frequency_spectrum(), ef_from_file.get_frequency_spectrum(),
+        atol=1e-8, rtol=1e-6)
+
+    if cleanup and os.path.isfile(test_filepath):
+        os.remove(test_filepath)
+
 
 if __name__ == "__main__":
     test_detector()
+    test_detector(always_query_entire_description=False)


### PR DESCRIPTION
In principle this is not strictly an error, i.e., it is possible to export a complete description without the flag set. So it could have been an warning but I thought a error is more prominent and the other case should not be necessary.