### PR TITLE
Time-dependent templates for impulse response

### DIFF
--- a/NuRadioReco/detector/RNO_G/db_mongo_read.py
+++ b/NuRadioReco/detector/RNO_G/db_mongo_read.py
@@ -1083,6 +1083,7 @@ class Database(object):
             channel_signal_id=channel_signal_id, measurement_name=measurement_name, verbose=verbose)
 
         for chain_key in ['response_chain', 'trigger_response_chain']:
+            templates_to_append = []
 
             # Not every channel has a trigger response chain
             if chain_key not in channel_sig_info:
@@ -1090,23 +1091,45 @@ class Database(object):
 
             # go through the component list query the corresponing measurements from the database (s parameters)
             for ice, component_entry in enumerate(channel_sig_info[chain_key]):
-                if component_entry["collection"] in ["gain_calibration", "time_delays"]:
-                    # only load a single calibration value
+                component_data_template = None
+                if component_entry["collection"] == "gain_calibration":
                     component_data = self.get_time_dependent_factor(
                         collection=component_entry["collection"], search_id=component_entry["id"])
+                    
+                    if "time_dependent_template" in component_data.keys():
+                        template_name = component_data["time_dependent_template"]["name"]
+                        component_data_template = {"collection": "full_chain"}
+                        component_data_template["name"] = template_name
+                        component_data_template.update(self.get_component_data(
+                            collection_name="full_chain",
+                            component_name=component_data["time_dependent_template"]["name"],
+                            sparameter="S21",
+                            verbose=verbose))
+                    else:
+                        component_data_template = None
+
+                elif component_entry["collection"] == "time_delays":
+                    component_data = self.get_time_dependent_factor(
+                        collection=component_entry["collection"], search_id=component_entry["id"])
+                    
                 else:
                     # create a search dict with addtional informations
                     supp_info = {key: component_entry[key] for key in component_entry.keys() if re.search("(channel|breakout)", key)}
-
+                    
                     component_data = self.get_component_data(
                         collection_name=component_entry["collection"],
                         component_name=component_entry["name"],
                         supplementary_info=supp_info,
                         verbose=verbose,
                         sparameter='S21')
-
                 # add the component data to the channel_sig_info dict
                 channel_sig_info[chain_key][ice].update(component_data)
+                
+                if component_data_template is not None: 
+                    templates_to_append.append(component_data_template)
+            
+            channel_sig_info[chain_key].extend(templates_to_append)
+
 
         return channel_sig_info
 

--- a/NuRadioReco/detector/RNO_G/db_mongo_read.py
+++ b/NuRadioReco/detector/RNO_G/db_mongo_read.py
@@ -1103,13 +1103,13 @@ class Database(object):
                     component_data = self.get_time_dependent_factor(
                         collection=component_entry["collection"], search_id=component_entry["id"])
                     
-                    if "time_dependent_template" in component_data.keys():
-                        template_name = component_data["time_dependent_template"]["name"]
+                    if "template_response" in component_data.keys():
+                        template_name = component_data["template_response"]["name"]
                         component_data_template = {"collection": "full_chain"}
                         component_data_template["name"] = template_name
                         component_data_template.update(self.get_component_data(
                             collection_name="full_chain",
-                            component_name=component_data["time_dependent_template"]["name"],
+                            component_name=component_data["template_response"]["name"],
                             sparameter="S21",
                             verbose=verbose))
                     else:

--- a/NuRadioReco/detector/RNO_G/db_mongo_read.py
+++ b/NuRadioReco/detector/RNO_G/db_mongo_read.py
@@ -193,6 +193,13 @@ class Database(object):
 
     def get_detector_time(self):
         return self.__detector_time
+    
+    def check_database_time(self):
+        if self.__database_time is None:
+            self.set_database_time(datetime.datetime.now(tz=datetime.timezone.utc))
+            logger.warning("Database time is not set, setting to current time.")
+        else:
+            logger.info(f"Database time is set to {self.__database_time}.")
 
     def find_primary_measurement(self, collection_name, name, primary_time, identification_label, data_dict):
         """

--- a/NuRadioReco/detector/RNO_G/db_mongo_read.py
+++ b/NuRadioReco/detector/RNO_G/db_mongo_read.py
@@ -141,6 +141,8 @@ class Database(object):
 
         self.__digitizer_collection = "digitizer_configuration"
 
+        self.__gain_calibration_collection = "gain_calibration"
+
 
 
     def set_database_time(self, time):
@@ -193,7 +195,7 @@ class Database(object):
 
     def get_detector_time(self):
         return self.__detector_time
-    
+
     def check_database_time(self):
         if self.__database_time is None:
             self.set_database_time(datetime.datetime.now(tz=datetime.timezone.utc))
@@ -892,9 +894,9 @@ class Database(object):
 
     def get_time_dependent_factor(self, collection, search_id, measurement_name=None, use_primary_time=None):
         """
-        Get the time dependent factor for a given station and channel id for the current detector time. 
+        Get the time dependent factor for a given station and channel id for the current detector time.
         Time dependent factors are quantities that have commissioning and decommissioning times (e.g., gain calibration values or time delays).
-        
+
         Parameters
         ----------
         collection: string
@@ -1102,7 +1104,7 @@ class Database(object):
                 if component_entry["collection"] == "gain_calibration":
                     component_data = self.get_time_dependent_factor(
                         collection=component_entry["collection"], search_id=component_entry["id"])
-                    
+
                     if "time_dependent_template" in component_data.keys():
                         template_name = component_data["time_dependent_template"]["name"]
                         component_data_template = {"collection": "full_chain"}
@@ -1118,11 +1120,11 @@ class Database(object):
                 elif component_entry["collection"] == "time_delays":
                     component_data = self.get_time_dependent_factor(
                         collection=component_entry["collection"], search_id=component_entry["id"])
-                    
+
                 else:
                     # create a search dict with addtional informations
                     supp_info = {key: component_entry[key] for key in component_entry.keys() if re.search("(channel|breakout)", key)}
-                    
+
                     component_data = self.get_component_data(
                         collection_name=component_entry["collection"],
                         component_name=component_entry["name"],
@@ -1131,10 +1133,10 @@ class Database(object):
                         sparameter='S21')
                 # add the component data to the channel_sig_info dict
                 channel_sig_info[chain_key][ice].update(component_data)
-                
-                if component_data_template is not None: 
+
+                if component_data_template is not None:
                     templates_to_append.append(component_data_template)
-            
+
             channel_sig_info[chain_key].extend(templates_to_append)
 
 
@@ -1266,7 +1268,25 @@ class Database(object):
             channel_times_comm = self.db[self.__station_collection].distinct("channels.commission_time", {"id": station_id})
             channel_times_decomm = self.db[self.__station_collection].distinct("channels.decommission_time", {"id": station_id})
 
-            mod_set = np.unique(station_times_comm + station_times_decomm + channel_times_comm + channel_times_decomm)
+            # # get set of (de)commission times for calibrations
+            available_ids = self.db[self.__gain_calibration_collection].distinct("id")
+            for id in available_ids:
+                if not id.startswith("sta"):
+                    logger.warning(
+                        f"Found gain calibration entry with unexpected ID: {id}. "
+                        "This is not expected and this entry will be ignored for the modification timestamp query.")
+
+            # HACK: This is not strictly correct as it is not acnostic to the specific version of the calibration
+            # (e.g., measurement_name), we might select additional unnecessary modification timestamps.
+            calibration_times_comm = self.db[self.__gain_calibration_collection].distinct(
+                "commission_time", {"id": {"$regex": f'^sta{station_id}_'}})  # already returns unique values
+            calibration_times_decomm = self.db[self.__gain_calibration_collection].distinct(
+                "decommission_time", {"id": {"$regex": f'^sta{station_id}_'}})  # already returns unique values
+
+            mod_set = np.unique(
+                station_times_comm + station_times_decomm +
+                channel_times_comm + channel_times_decomm +
+                calibration_times_comm + calibration_times_decomm).tolist()
             mod_set.sort()
             station_times_comm.sort()
             station_times_decomm.sort()

--- a/NuRadioReco/detector/RNO_G/db_mongo_write.py
+++ b/NuRadioReco/detector/RNO_G/db_mongo_write.py
@@ -118,7 +118,7 @@ class Database(NuRadioReco.detector.RNO_G.db_mongo_read.Database):
             If this quantity is given, the start time of the primary measurement is set to this value. Otherwise, the primary start time will be set to the current time
         """
 
-        #self.set_database_time(datetime.datetime.now(tz=datetime.timezone.utc))
+        self.check_database_time()
 
         # close the time period of the old primary measurement
         if primary_measurement and identification_value in self.db[collection].distinct(identification_key):
@@ -170,7 +170,7 @@ class Database(NuRadioReco.detector.RNO_G.db_mongo_read.Database):
             If this quantity is given, the start time of the primary measurement is set to this value. Otherwise, the primary start time will be set to the current time
         """
 
-        #self.set_database_time(datetime.datetime.now(tz=datetime.timezone.utc))
+        self.check_database_time()
 
         search_dict = {identification_key: identification_value,
                        "commission_time": commission_time,
@@ -352,7 +352,7 @@ class Database(NuRadioReco.detector.RNO_G.db_mongo_read.Database):
             If this argument is given, the end of the current primary measurement is set to this timestamp (instead of now).
         """
         # Use database_time instead of current time
-        #present_time = datetime.datetime.now(tz=datetime.timezone.utc)
+        self.check_database_time()
         present_time = self.get_database_time()
 
         # find the current primary measurement

--- a/NuRadioReco/detector/RNO_G/db_mongo_write.py
+++ b/NuRadioReco/detector/RNO_G/db_mongo_write.py
@@ -118,7 +118,7 @@ class Database(NuRadioReco.detector.RNO_G.db_mongo_read.Database):
             If this quantity is given, the start time of the primary measurement is set to this value. Otherwise, the primary start time will be set to the current time
         """
 
-        self.set_database_time(datetime.datetime.now(tz=datetime.timezone.utc))
+        #self.set_database_time(datetime.datetime.now(tz=datetime.timezone.utc))
 
         # close the time period of the old primary measurement
         if primary_measurement and identification_value in self.db[collection].distinct(identification_key):
@@ -170,7 +170,7 @@ class Database(NuRadioReco.detector.RNO_G.db_mongo_read.Database):
             If this quantity is given, the start time of the primary measurement is set to this value. Otherwise, the primary start time will be set to the current time
         """
 
-        self.set_database_time(datetime.datetime.now(tz=datetime.timezone.utc))
+        #self.set_database_time(datetime.datetime.now(tz=datetime.timezone.utc))
 
         search_dict = {identification_key: identification_value,
                        "commission_time": commission_time,
@@ -351,8 +351,9 @@ class Database(NuRadioReco.detector.RNO_G.db_mongo_read.Database):
         primary_end_time: datetime.datetime or None
             If this argument is given, the end of the current primary measurement is set to this timestamp (instead of now).
         """
-
-        present_time = datetime.datetime.now(tz=datetime.timezone.utc)
+        # Use database_time instead of current time
+        #present_time = datetime.datetime.now(tz=datetime.timezone.utc)
+        present_time = self.get_database_time()
 
         # find the current primary measurement
         obj_id, measurement_id = self.find_primary_measurement(

--- a/NuRadioReco/detector/RNO_G/rnog_detector.py
+++ b/NuRadioReco/detector/RNO_G/rnog_detector.py
@@ -951,13 +951,16 @@ class Detector():
                     y_units = component_entry["gain_factor_unit"]
                     frequencies = None
                     time_delay = 0
+                    weight = component_entry.get("weight", 1)  # returns 1 as the default if weight is not included
+                    attenuator = component_entry.get("attenuator", 0) # returns 0 as the default if attenuator is not included
 
                 elif component_entry['collection'] == "time_delays":
                     ydata = 1  # Fake gain factor of 1 in magitude (does nothing)
                     y_units = "mag"
                     frequencies = None
                     time_delay = component_entry["time_delay"] * getattr(units, component_entry["time_delay_unit"])
-
+                    weight = component_entry.get("weight", 1)  # returns 1 as the default if weight is not included
+                    attenuator = component_entry.get("attenuator", 0) # returns 0 as the default if attenuator is not included
 
                 else:
                     # Get the response data
@@ -990,7 +993,6 @@ class Detector():
                             ydata[0] = np.asarray(ydata[0]) * 10 ** (attenuator / 20)
                         else:
                             raise KeyError
-
                 response = Response(
                     frequencies, ydata, y_units,
                     time_delay=time_delay, weight=weight,

--- a/NuRadioReco/detector/RNO_G/rnog_detector.py
+++ b/NuRadioReco/detector/RNO_G/rnog_detector.py
@@ -952,7 +952,6 @@ class Detector():
                     frequencies = None
                     time_delay = 0
                     weight = component_entry.get("weight", 1)  # returns 1 as the default if weight is not included
-                    attenuator = component_entry.get("attenuator", 0) # returns 0 as the default if attenuator is not included
 
                 elif component_entry['collection'] == "time_delays":
                     ydata = 1  # Fake gain factor of 1 in magitude (does nothing)
@@ -960,7 +959,6 @@ class Detector():
                     frequencies = None
                     time_delay = component_entry["time_delay"] * getattr(units, component_entry["time_delay_unit"])
                     weight = component_entry.get("weight", 1)  # returns 1 as the default if weight is not included
-                    attenuator = component_entry.get("attenuator", 0) # returns 0 as the default if attenuator is not included
 
                 else:
                     # Get the response data


### PR DESCRIPTION
- In the new calibrated impulse responses from @CamphynR, the best-fitting template is determined seperately each year. Since we don't store time-dependent impulse responses in the DB, we (me and @jakobhenrichs ) decided to assign these templates to the `gain_calibration` collection under the correct station/channel and year. Since there is no `full_chain` entry (template) in the new signal chain, I adjusted the `db_mongo_read.py` script to obtain the impulse response template from the `gain_calibration` collection (also works for the previous impulse response, where the templates were not time-dependent):
**New `signal_chain` entry:**
<img width="753" height="494" alt="Screenshot 2026-02-11 at 22 55 26" src="https://github.com/user-attachments/assets/4bd593aa-4935-4a4a-9192-0d78f7d80113" />

**New `gain_calibration` entry:**
<img width="634" height="354" alt="Screenshot 2026-02-11 at 22 56 01" src="https://github.com/user-attachments/assets/fe4c0483-46d0-4c61-b30c-7a6ad56ba6dc" />
- I adjusted the `db_mongo_write.py` script to be able to update a primary measurement far in the future. The older version only updates the current primary measurement.
- The missing weight/attenuator for the collections `gain_calibration` and `time_delay` causes errors when "full_chain" is not the first `response_chain` component