### PR TITLE
Add custom (user-specified) amplifiers

### DIFF
--- a/NuRadioReco/detector/RNO_G/analog_components.py
+++ b/NuRadioReco/detector/RNO_G/analog_components.py
@@ -1,12 +1,13 @@
 import numpy as np
+import logging
 from scipy.interpolate import interp1d
 import os
 from NuRadioReco.utilities import units
+from functools import lru_cache
 from radiotools import helper as hp
-import logging
 logger = logging.getLogger('NuRadioReco.analog_components')
 
-
+@lru_cache(maxsize=128)
 def load_amp_response(amp_type='rno_surface', temp=293.15,
                       path=os.path.dirname(os.path.realpath(__file__))):  # use this function to read in log data
     """

--- a/NuRadioReco/detector/RNO_G/analog_components.py
+++ b/NuRadioReco/detector/RNO_G/analog_components.py
@@ -11,11 +11,11 @@ logger = logging.getLogger('NuRadioReco.analog_components')
 def load_amp_response(amp_type='rno_surface', temp=293.15,
                       path=os.path.dirname(os.path.realpath(__file__))):  # use this function to read in log data
     """
-    Read out amplifier gain and phase. Currently only examples have been implemented.
-    Needs a better structure in the future, possibly with database.
-    The hardware response incorporator currently reads in the load amp response.
-    If you want to read in the RI function for your reconstruction it needs to be changed
-    in modules/RNO_G/hardweareResponseIncorporator.py l. 52, amp response.
+    Read out amplifier gain and phase.
+
+    These are all 'placeholder' measurements of a single reference amplifier/signal chain;
+    more up-to-date, channel-specific amplifier responses may be loaded via
+    the :class:`rnog_detector <NuRadioReco.detector.RNO_G.rnog_detector.Detector>` class.
     
     Temperature dependence: the function loads a reference measurement made at room temperature
     and will correct it for the temperature. The correction function is obtained empirically for
@@ -28,6 +28,8 @@ def load_amp_response(amp_type='rno_surface', temp=293.15,
         * "rno_surface": the surface signal chain
         * "iglu": the in-ice signal chain
         * "phased_array": the additional filter of the phased array channels before going into the phased array trigger. 
+        * "rno_surface_impulse": alternative measurement of the surface signal chain response, including the RADIANT
+        * "deep_impulse": alternative measurement of the deep (iglu) signal chain response, including the RADIANT
     temp: float (default 293.15K)
         the default temperature in Kelvin that the amplifier response is corrected for
     """
@@ -106,4 +108,5 @@ def load_amp_response(amp_type='rno_surface', temp=293.15,
 
 
 def get_available_amplifiers():
+    """Returns a list of available amplifiers"""
     return ['iglu', 'deep_impulse', 'rno_surface', 'rno_surface_impulse', 'phased_array', 'ULP_216']

--- a/NuRadioReco/detector/amps/custom/README.md
+++ b/NuRadioReco/detector/amps/custom/README.md
@@ -1,0 +1,9 @@
+Custom amplifier responses can be implemented by including them as CSV files under this directory.
+
+They should be included as {amp_type}.csv, with the columns frequency (in Hz), S21 (magnitude), S21 phase (in radians).
+They may include one or several 'header' lines, but these should be prefaced with #. Example:
+
+    # Custom amplifier response for Gen2 detector simulation
+    # Frequency [Hz], S21 [mag], S21 [phase] [rad]
+    1000000., 0.300000, 0.400000
+    (...)

--- a/NuRadioReco/detector/detector_base.py
+++ b/NuRadioReco/detector/detector_base.py
@@ -1109,14 +1109,16 @@ def _load_custom_amp(amp_type, directory=os.path.join(os.path.dirname(__file__),
     amp_csv = np.loadtxt(custom_amps[amp_type])
     assert amp_csv.shape[1] == 3, "Custom amplifier response does not have expected format (frequency in Hz, S21 mag, S21 phase in rad)"
 
-    # for some strange reason 'phase' in response_functions is actually the magnitude-normalized complex response
-    interp_phase = scipy.interpolate.make_interp_spline(amp_csv[:,0] * units.Hz, amp_csv[:,2], k=1)
-    def get_phase(freqs):
-        return np.exp(1j * interp_phase(freqs))
+    def interp_amp(freqs):
+        return np.interp(freqs, amp_csv[:,0] * units.Hz, amp_csv[:,1], left=0, right=0)
+
+    # for some reason 'phase' in response_functions is actually the magnitude-normalized complex response
+    def interp_phase(freqs):
+        return np.exp(1j * np.interp(freqs, amp_csv[:,0] * units.Hz, amp_csv[:,2], left=0, right=0))
 
     response_functions = dict(
-        gain = scipy.interpolate.make_interp_spline(amp_csv[:,0] * units.Hz, amp_csv[:,1], k=1),
-        phase = get_phase
+        gain = interp_amp,
+        phase = interp_phase
     )
 
     return response_functions

--- a/NuRadioReco/detector/detector_base.py
+++ b/NuRadioReco/detector/detector_base.py
@@ -1,4 +1,7 @@
 import numpy as np
+import glob
+from functools import lru_cache
+import scipy.interpolate
 from NuRadioReco.utilities import units
 import NuRadioReco.detector.RNO_G.analog_components
 import NuRadioReco.detector.ARIANNA.analog_components
@@ -862,11 +865,12 @@ class DetectorBase(object):
         if 'amp_type' in res.keys():
             amp_type = res['amp_type']
         if amp_type is None:
-            raise ValueError(
-                'Amplifier type for station {}, channel {} not in detector description'.format(
+            logger.error(
+                'Amplifier type for station {}, channel {} not in detector description. No amplifier response will be applied.'.format(
                     station_id,
                     channel_id
                 ))
+            return np.ones_like(frequencies, dtype=complex)
         amp_response_functions = None
         if amp_type in NuRadioReco.detector.RNO_G.analog_components.get_available_amplifiers():
             amp_response_functions = NuRadioReco.detector.RNO_G.analog_components.load_amp_response(amp_type)
@@ -874,6 +878,12 @@ class DetectorBase(object):
             if amp_response_functions is not None:
                 raise ValueError('Amplifier name {} is not unique'.format(amp_type))
             amp_response_functions = NuRadioReco.detector.ARIANNA.analog_components.load_amplifier_response(amp_type)
+        # check for custom amplifier responses
+        if _load_custom_amp(amp_type) is not None:
+            if amp_response_functions is not None:
+                raise ValueError(f'Custom amplifier type {amp_type} is already in use. Please rename your custom amplifier.')
+            amp_response_functions = _load_custom_amp(amp_type)
+
         if amp_response_functions is None:
             raise ValueError('Amplifier of type {} not found'.format(amp_type))
         amp_gain = amp_response_functions['gain'](frequencies)
@@ -1080,3 +1090,33 @@ class DetectorBase(object):
         if 'noiseless' not in res:
             return False
         return res['noiseless']
+
+
+@lru_cache(maxsize=128)
+def _load_custom_amp(amp_type, directory=os.path.join(os.path.dirname(__file__), 'amps', 'custom')):
+    """
+    List custom amplifiers (in CSV format) available under ``directory``.
+
+    Note that this expects the amplifier response to be in a fixed format:
+    3 columns (frequency in Hz, S21 magnitude, S21 phase in radians)
+
+    """
+    custom_amp_files = glob.glob(os.path.join(directory, '*.csv'))
+    custom_amps = {os.path.basename(f).strip('.csv') : f for f in custom_amp_files}
+    if amp_type not in custom_amps:
+        return None
+
+    amp_csv = np.loadtxt(custom_amps[amp_type])
+    assert amp_csv.shape[1] == 3, "Custom amplifier response does not have expected format (frequency in Hz, S21 mag, S21 phase in rad)"
+
+    # for some strange reason 'phase' in response_functions is actually the magnitude-normalized complex response
+    interp_phase = scipy.interpolate.make_interp_spline(amp_csv[:,0] * units.Hz, amp_csv[:,2], k=1)
+    def get_phase(freqs):
+        return np.exp(1j * interp_phase(freqs))
+
+    response_functions = dict(
+        gain = scipy.interpolate.make_interp_spline(amp_csv[:,0] * units.Hz, amp_csv[:,1], k=1),
+        phase = get_phase
+    )
+
+    return response_functions

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,8 @@ please update the categories "new features" and "bugfixes" before a pull request
 
 version 3.2.0-dev
 new features:
+- Added the option to use custom (user-specified) amplifiers. Custom amplifiers can be provided as .csv files
+  under NuRadioReco/detector/amps/custom.
 
 bugfixes:
 


### PR DESCRIPTION
This PR makes two changes:
- It allows to provide custom amplifiers as .csv files under `NuRadioReco/detector/amps/custom`. While it is already possible to do all kinds of custom processing during the simulation (by implementing custom logic in `_detector_simulation_filter_amp`), it is not so easy to retrieve this afterwards, e.g. for analysis/reconstruction. This PR allows users to specify custom amplifier responses in  a way that makes this (hopefully) easier to generalize; I used it for example in the reconstruction of simulated IceCube-Gen2 events.
- It also no longer raises an error if no amplifier is specified in the detector (though it will very noisily emit error messages), but instead default to a unit response. This makes it possible to simulate no amplifier while still reminding the user that this is very naughty and should not be done unintentionally (I implemented this a fairly long time ago and am no longer so sure why).

For context, this is part of #1010 but I figured this is an isolated feature which would be easier to review separately.