### PR TITLE
Store shower Xmax in simulated shower when simulating with ARZ

### DIFF
--- a/NuRadioMC/SignalGen/ARZ/ARZ.py
+++ b/NuRadioMC/SignalGen/ARZ/ARZ.py
@@ -607,63 +607,62 @@ class ARZ(object):
         # to the Cherenkov angle, but NuRadioMC will reuse the shower realization of the first ray tracing solution.
         if np.abs(theta - cherenkov_angle) > maximum_angle:
             logger.info(f"viewing angle {theta/units.deg:.1f}deg is more than {maximum_angle/units.deg:.1f}deg away from the Cherenkov cone. Returning zero trace.")
-            empty_trace = np.zeros((3, N))
-            return empty_trace
+            trace_onsky = np.zeros((3, N))
+        else:
+            # get the appropriate model parameters
+            if shower_type == "HAD":
+                model_parameters = dict(
+                    Af = self._Af_p,
+                    t0_pos = self._t0_p_pos,
+                    freq_pos = self._freq_p_pos,
+                    exp_pos = self._exp_p_pos,
+                    t0_neg = self._t0_p_neg,
+                    freq_neg = self._freq_p_neg,
+                    exp_neg = self._exp_p_neg
+                )
+                em_factor = self.em_fraction(shower_energy)
+            elif shower_type == "EM":
+                model_parameters = dict(
+                    Af = self._Af_e,
+                    t0_pos = self._t0_e_pos,
+                    freq_pos = self._freq_e_pos,
+                    exp_pos = self._exp_e_pos,
+                    t0_neg = self._t0_e_neg,
+                    freq_neg = self._freq_e_neg,
+                    exp_neg = self._exp_e_neg
+                )
+                em_factor = 1.
+            elif(shower_type == "TAU"):
+                logger.error("Tau showers are not yet implemented")
+                raise NotImplementedError("Tau showers are not yet implemented")
+            else:
+                msg = "showers of type {} are not implemented. Use 'HAD', 'EM'".format(shower_type)
+                logger.error(msg)
+                raise NotImplementedError(msg)
+            if self._use_numba:
+                vp = get_vector_potential_numba(
+                    shower_energy, theta, N, dt, profile_depth, profile_ce,
+                    shower_type=shower_type, n_index=n_index, distance=R,
+                    interp_factor=self._interp_factor, interp_factor2=self._interp_factor2,
+                    shift_for_xmax=shift_for_xmax, **model_parameters, em_factor=em_factor
+                )
+            else:
+                vp = get_vector_potential(
+                    shower_energy, theta, N, dt, profile_depth, profile_ce,
+                    shower_type=shower_type, n_index=n_index, distance=R,
+                    interp_factor=self._interp_factor, interp_factor2=self._interp_factor2,
+                    shift_for_xmax=shift_for_xmax, **model_parameters, em_factor=em_factor
+                )
+            trace = -np.diff(vp, axis=0) / dt
 
-        # get the appropriate model parameters
-        if shower_type == "HAD":
-            model_parameters = dict(
-                Af = self._Af_p,
-                t0_pos = self._t0_p_pos,
-                freq_pos = self._freq_p_pos,
-                exp_pos = self._exp_p_pos,
-                t0_neg = self._t0_p_neg,
-                freq_neg = self._freq_p_neg,
-                exp_neg = self._exp_p_neg
-            )
-            em_factor = self.em_fraction(shower_energy)
-        elif shower_type == "EM":
-            model_parameters = dict(
-                Af = self._Af_e,
-                t0_pos = self._t0_e_pos,
-                freq_pos = self._freq_e_pos,
-                exp_pos = self._exp_e_pos,
-                t0_neg = self._t0_e_neg,
-                freq_neg = self._freq_e_neg,
-                exp_neg = self._exp_e_neg
-            )
-            em_factor = 1.
-        elif(shower_type == "TAU"):
-            logger.error("Tau showers are not yet implemented")
-            raise NotImplementedError("Tau showers are not yet implemented")
-        else:
-            msg = "showers of type {} are not implemented. Use 'HAD', 'EM'".format(shower_type)
-            logger.error(msg)
-            raise NotImplementedError(msg)
-        if self._use_numba:
-            vp = get_vector_potential_numba(
-                shower_energy, theta, N, dt, profile_depth, profile_ce,
-                shower_type=shower_type, n_index=n_index, distance=R,
-                interp_factor=self._interp_factor, interp_factor2=self._interp_factor2,
-                shift_for_xmax=shift_for_xmax, **model_parameters, em_factor=em_factor
-            )
-        else:
-            vp = get_vector_potential(
-                shower_energy, theta, N, dt, profile_depth, profile_ce,
-                shower_type=shower_type, n_index=n_index, distance=R,
-                interp_factor=self._interp_factor, interp_factor2=self._interp_factor2,
-                shift_for_xmax=shift_for_xmax, **model_parameters, em_factor=em_factor
-            )
-        trace = -np.diff(vp, axis=0) / dt
-#         trace = -np.gradient(vp, axis=0) / dt
+            # use viewing angle relative to shower maximum for rotation into spherical coordinate system (that reduced eR component)
+            if shift_for_xmax:  # if we shifted the observerposition already to be relative to Xmax, we don't need to do that here.
+                thetaprime = theta
+            else:
+                thetaprime = theta_to_thetaprime(theta, xmax, R)
+            cs = cstrafo.cstrafo(zenith=thetaprime, azimuth=0)
+            trace_onsky = cs.transform_from_ground_to_onsky(trace.T)
 
-        # use viewing angle relative to shower maximum for rotation into spherical coordinate system (that reduced eR component)
-        if shift_for_xmax:  # if we shifted the observerposition already to be relative to Xmax, we don't need to do that here.
-            thetaprime = theta
-        else:
-            thetaprime = theta_to_thetaprime(theta, xmax, R)
-        cs = cstrafo.cstrafo(zenith=thetaprime, azimuth=0)
-        trace_onsky = cs.transform_from_ground_to_onsky(trace.T)
         if(output_mode == 'full'):
             return trace_onsky, profile_depth, profile_ce
         elif(output_mode == 'Xmax'):

--- a/NuRadioMC/SignalGen/askaryan.py
+++ b/NuRadioMC/SignalGen/askaryan.py
@@ -125,8 +125,11 @@ def get_time_trace(energy, theta, N, dt, shower_type, n_index, R, model, interp_
 
         if(interp_factor2 is not None):
             gARZ.set_interpolation_factor2(interp_factor2)
-        trace = gARZ.get_time_trace(energy, theta, N, dt, shower_type, n_index, R, same_shower=same_shower, **kwargs)[1]
+        trace, profile_depth, profile_ce = gARZ.get_time_trace(energy, theta, N, dt, shower_type, n_index, R, same_shower=same_shower, output_mode="full", **kwargs)
+        trace = trace[1] # return the theta component; the ARZ class uses a fixed geometry where this is the only non-zero component
         additional_output['iN'] = gARZ.get_last_shower_profile_id()[shower_type]
+        additional_output['profile_depth'] = profile_depth
+        additional_output['profile_ce'] = profile_ce
 
     elif(model == 'spherical'):
         amplitude = 1. * energy / R

--- a/NuRadioMC/simulation/simulation.py
+++ b/NuRadioMC/simulation/simulation.py
@@ -236,6 +236,9 @@ def calculate_sim_efield(
                 if not shower.has_parameter(shp.charge_excess_profile_id):
                     shower.set_parameter(shp.charge_excess_profile_id, additional_output['iN'])
                     logger.debug(f"setting shower profile for ARZ shower library to i = {additional_output['iN']}")
+                if not shower.has_parameter(shp.shower_maximum):
+                    shower_xmax = additional_output['profile_depth'][np.argmax(additional_output['profile_ce'])]
+                    shower.set_parameter(shp.shower_maximum, shower_xmax)
 
             if config['signal']['model'] == "Alvarez2009":
                 if not shower.has_parameter(shp.k_L):

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@ please update the categories "new features" and "bugfixes" before a pull request
 
 version 3.2.0-dev
 new features:
+- Store shower Xmax in simulated shower when simulating with ARZ Askaryan emission models.
 - Added elevation to detector sites, and a corresponding `get_site_elevation` method to the `Detector` class. Altitudes were obtained
 from the NOAA ETOPO1 dataset via www.opentopodata.org.
 


### PR DESCRIPTION
Closes #1042 

Store the shower Xmax in the `shower_maximum` parameter when simulating with ARZ, similar to how the shower realization is already stored.

I guess there is some slight ambiguity in how we store Xmax (occasionally we refer to it as a length); I think probably the most sensible/consistent thing to do is to store it in units of weight / length^2, which is what I've done here.

I've also fixed a bug in the ARZ module where the signature expected from `output_mode` was not respected if an empty trace was returned (because we're too far from the Cherenkov angle).