### PR TITLE
replace deprecated numpy.trapz with scipy.integrate.trapezoid

### DIFF
--- a/NuRadioMC/EvtGen/generate_unforced.py
+++ b/NuRadioMC/EvtGen/generate_unforced.py
@@ -4,7 +4,7 @@ from matplotlib import pyplot as plt
 from radiotools import helper as hp
 from NuRadioMC.utilities import cross_sections as cs
 from NuRadioMC.utilities import earth_attenuation
-from scipy.integrate import quad
+from scipy.integrate import quad, trapezoid
 from scipy.optimize import brentq
 from scipy.interpolate import interp1d
 from NuRadioMC.simulation.time_logger import pretty_time_delta
@@ -216,7 +216,7 @@ def generate_eventlist_cylinder(filename, n_events, Emin, Emax,
         """
         tt = np.linspace(0, t, t / step)
         rr = np.linalg.norm(X + np.outer(tt, v), axis=1)
-        res = np.trapz(earth.density(rr), tt)
+        res = trapezoid(earth.density(rr), tt)
         return res
 
     def obj_dist_to_surface(t, v, X):

--- a/NuRadioMC/SignalGen/ARZ/ARZ.py
+++ b/NuRadioMC/SignalGen/ARZ/ARZ.py
@@ -15,8 +15,11 @@ try:
 except ImportError:
     numba_available = False
 
+if not hasattr(np, 'trapezoid'):
+    # needed for compatibility with old numpy versions
+    np.trapezoid = np.trapz
+
 logger = logging.getLogger("NuRadioMC.SignalGen.ARZ")
-# logger.setLevel(logging.INFO)
 
 ######################
 ######################
@@ -268,7 +271,7 @@ def get_vector_potential(
 #         F_p[~mask] = 1.e-30 * fc / xntot
         F_p[~mask] = 0
 
-        vp[it] = integrate.trapezoid(-v * profile_ce_interp2 * F_p / R, z)
+        vp[it] = np.trapezoid(-v * profile_ce_interp2 * F_p / R, z)
 
     vp *= factor
 
@@ -920,7 +923,7 @@ class ARZ(object):
     #         F_p[~mask] = 1.e-30 * fc / xntot
             F_p[~mask] = 0
 
-            vp[it] = integrate.trapezoid(-v * profile_ce_interp2 * F_p / R, z)
+            vp[it] = np.trapezoid(-v * profile_ce_interp2 * F_p / R, z)
             if  0:
                 import matplotlib.pyplot as plt
                 fig, ax = plt.subplots(1, 1)

--- a/NuRadioMC/SignalGen/ARZ/ARZ.py
+++ b/NuRadioMC/SignalGen/ARZ/ARZ.py
@@ -268,7 +268,7 @@ def get_vector_potential(
 #         F_p[~mask] = 1.e-30 * fc / xntot
         F_p[~mask] = 0
 
-        vp[it] = np.trapz(-v * profile_ce_interp2 * F_p / R, z)
+        vp[it] = integrate.trapezoid(-v * profile_ce_interp2 * F_p / R, z)
 
     vp *= factor
 
@@ -920,7 +920,7 @@ class ARZ(object):
     #         F_p[~mask] = 1.e-30 * fc / xntot
             F_p[~mask] = 0
 
-            vp[it] = np.trapz(-v * profile_ce_interp2 * F_p / R, z)
+            vp[it] = integrate.trapezoid(-v * profile_ce_interp2 * F_p / R, z)
             if  0:
                 import matplotlib.pyplot as plt
                 fig, ax = plt.subplots(1, 1)

--- a/NuRadioMC/simulation/simulation.py
+++ b/NuRadioMC/simulation/simulation.py
@@ -7,7 +7,7 @@ import copy
 import yaml
 import numpy as np
 import h5py
-from scipy import constants
+from scipy import constants, integrate
 from numpy.random import Generator, Philox
 
 from radiotools import helper as hp
@@ -1311,7 +1311,7 @@ class simulation:
                     np.abs(filt)[np.abs(filt) > np.abs(filt).max() / 100] ** 2)  # a factor of 100 corresponds to -40 dB in amplitude
                 self._integrated_channel_response_normalization[station_id][channel_id] = mean_integrated_response
 
-                integrated_channel_response = np.trapz(np.abs(filt) ** 2, ff)
+                integrated_channel_response = integrate.trapezoid(np.abs(filt) ** 2, ff)
                 self._integrated_channel_response[station_id][channel_id] = integrated_channel_response
 
                 logger.debug(f"Station.channel {station_id}.{channel_id} estimated bandwidth is "

--- a/NuRadioMC/utilities/earth_attenuation.py
+++ b/NuRadioMC/utilities/earth_attenuation.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 import numpy as np
+from scipy import integrate
 from NuRadioReco.utilities import units
 from NuRadioMC.utilities import cross_sections
 from radiotools import helper as hp
@@ -256,7 +257,7 @@ class PREM:
         zs = endpoint[2] + ts * distance * direction[2]
         rs = np.sqrt(xs ** 2 + ys ** 2 + zs ** 2)
         rhos = self.density(rs)
-        return np.trapz(rhos * distance, ts)
+        return integrate.trapezoid(rhos * distance, ts)
 
 
 class CoreMantleCrustModel(PREM):

--- a/NuRadioReco/examples/AirShowerFluenceXmaxReco/A02CoREASFluenceXmaxReco.py
+++ b/NuRadioReco/examples/AirShowerFluenceXmaxReco/A02CoREASFluenceXmaxReco.py
@@ -23,7 +23,7 @@ import logging
 import numpy as np
 from matplotlib import pyplot as plt
 from matplotlib import cm
-from scipy import constants
+from scipy import constants, integrate
 from scipy import optimize as opt
 from astropy import time
 from NuRadioReco.detector import detector
@@ -141,7 +141,7 @@ for iE, evt in enumerate(coreas_reader.run(det, [core])):
     max_freq = 0.5 * det.get_sampling_frequency(station.get_id(), 1)
     ff = np.linspace(0, max_freq, 10000)
     filt = channelBandPassFilter.get_filter(ff, station.get_id(), None, det, **filt_settings)
-    bandwidth = np.trapz(np.abs(filt) ** 2, ff)
+    bandwidth = integrate.trapezoid(np.abs(filt) ** 2, ff)
     Vrms = (Tnoise * 50 * constants.k * bandwidth / units.Hz) ** 0.5
     amplitude = Vrms/ (bandwidth / max_freq) ** 0.5
     channelGenericNoiseAdder.run(evt, station, det, type="rayleigh", amplitude=1 * amplitude,

--- a/NuRadioReco/examples/PhasedArray/Noise_trigger_rate/T01MeasureNoiselevel.py
+++ b/NuRadioReco/examples/PhasedArray/Noise_trigger_rate/T01MeasureNoiselevel.py
@@ -1,6 +1,7 @@
 import argparse
 import time
 import numpy as np
+from scipy import integrate
 from astropy.time import Time
 from multiprocessing import Pool as ThreadPool
 import NuRadioReco.modules.channelGenericNoiseAdder
@@ -83,7 +84,7 @@ fff = np.linspace(min_freq, max_freq, 10000)
 filt1_highres = channelBandPassFilter.get_filter(fff, 0, 0, None, passband=[0, 220 * units.MHz], filter_type="cheby1", order=7, rp=.1)
 filt2_highres = channelBandPassFilter.get_filter(fff, 0, 0, None, passband=[96 * units.MHz, 100 * units.GHz], filter_type="cheby1", order=4, rp=.1)
 filt_highres = filt1_highres * filt2_highres
-bandwidth = np.trapz(np.abs(filt_highres) ** 2, fff)
+bandwidth = integrate.trapezoid(np.abs(filt_highres) ** 2, fff)
 
 Vrms_ratio = np.sqrt(bandwidth / (max_freq - min_freq))
 amplitude = Vrms / Vrms_ratio

--- a/NuRadioReco/examples/PhasedArray/SNR_curves/T02RunSNR.py
+++ b/NuRadioReco/examples/PhasedArray/SNR_curves/T02RunSNR.py
@@ -28,6 +28,7 @@ import json
 import logging
 import copy
 import numpy as np
+from scipy import integrate
 from NuRadioMC.simulation import simulation
 import NuRadioReco.modules.efieldToVoltageConverter
 import NuRadioReco.modules.trigger.simpleThreshold
@@ -92,7 +93,7 @@ fff = np.linspace(min_freq, max_freq, 10000)
 filt1_highres = channelBandPassFilter.get_filter(fff, 0, 0, None, passband=[0, 220 * units.MHz], filter_type="cheby1", order=7, rp=.1)
 filt2_highres = channelBandPassFilter.get_filter(fff, 0, 0, None, passband=[96 * units.MHz, 100 * units.GHz], filter_type="cheby1", order=4, rp=.1)
 filt_highres = filt1_highres * filt2_highres
-bandwidth = np.trapz(np.abs(filt_highres) ** 2, fff)
+bandwidth = integrate.trapezoid(np.abs(filt_highres) ** 2, fff)
 Vrms_ratio = np.sqrt(bandwidth / (max_freq - min_freq))
 
 Vrms = 1

--- a/NuRadioReco/examples/PhasedArray/SNR_curves/T02RunSNR_RNOG.py
+++ b/NuRadioReco/examples/PhasedArray/SNR_curves/T02RunSNR_RNOG.py
@@ -27,6 +27,7 @@ import argparse
 import json
 import copy
 import numpy as np
+from scipy import integrate
 from NuRadioMC.simulation import simulation
 import NuRadioReco.modules.efieldToVoltageConverter
 import NuRadioReco.modules.trigger.simpleThreshold
@@ -81,7 +82,7 @@ fff = np.linspace(min_freq, max_freq, 10000)
 filt1_highres = channelBandPassFilter.get_filter(fff, 0, 0, None, passband=[0, 240 * units.MHz], filter_type="cheby1", order=9, rp=.1)
 filt2_highres = channelBandPassFilter.get_filter(fff, 0, 0, None, passband=[80 * units.MHz, 230 * units.MHz], filter_type="cheby1", order=4, rp=.1)
 filt_highres = filt1_highres * filt2_highres
-bandwidth = np.trapz(np.abs(filt_highres) ** 2, fff)
+bandwidth = integrate.trapezoid(np.abs(filt_highres) ** 2, fff)
 Vrms_ratio = np.sqrt(bandwidth / (max_freq - min_freq))
 
 new_sampling_rate = 500.0 * units.MHz

--- a/NuRadioReco/modules/channelGenericNoiseAdder.py
+++ b/NuRadioReco/modules/channelGenericNoiseAdder.py
@@ -1,5 +1,6 @@
 import logging
 import numpy as np
+from scipy import integrate
 from numpy.random import Generator, Philox
 from NuRadioReco.utilities import units, fft
 from NuRadioReco.modules.base.module import register_run
@@ -339,7 +340,7 @@ class channelGenericNoiseAdder:
 
         if amplitude is not None:
             # power = np.sum(spectrum**2)
-            norm = np.trapz(np.abs(spectrum) ** 2, frequencies)
+            norm = integrate.trapezoid(np.abs(spectrum) ** 2, frequencies)
             max_freq = frequencies[-1]
             amplitude = amplitude / (norm / max_freq) ** 0.5
             sigscale = (1. * n_samples) / np.sqrt(n_samples_freq)

--- a/NuRadioReco/utilities/noise.py
+++ b/NuRadioReco/utilities/noise.py
@@ -3,7 +3,7 @@ from NuRadioReco.modules import channelGenericNoiseAdder
 from NuRadioReco.utilities import units, fft
 from NuRadioReco.modules.trigger.highLowThreshold import get_high_low_triggers
 from NuRadioReco.detector import generic_detector as detector
-from scipy import constants
+from scipy import constants, integrate
 import datetime
 import scipy
 import scipy.signal
@@ -213,7 +213,7 @@ class thermalNoiseGenerator():
         self.norm = {}
         self.amplitude = {}
         for i in range(n_channels):
-            self.norm[i] = np.trapz(np.abs(self.filt[i]) ** 2, self.ff)
+            self.norm[i] = integrate.trapezoid(np.abs(self.filt[i]) ** 2, self.ff)
             self.amplitude[i] = (self.max_freq - self.min_freq) ** 0.5 / self.norm[i] ** 0.5 * self.Vrms[i]
 
         self.noise = channelGenericNoiseAdder.channelGenericNoiseAdder()
@@ -405,7 +405,7 @@ class thermalNoiseGeneratorPhasedArray():
                                  f" frequency binning of {len(self.ff)} bins from {self.ff[0] / units.MHz:.0f} to {self.ff[-1] / units.MHz:.0f} MHz")
             self.filt = np.array(filt)
 
-        self.norm = np.trapz(np.abs(self.filt) ** 2, self.ff)
+        self.norm = integrate.trapezoid(np.abs(self.filt) ** 2, self.ff)
         self.amplitude = (self.max_freq - self.min_freq) ** 0.5 / self.norm ** 0.5 * self.Vrms
         logger.info(f"Vrms = {self.Vrms:.3g}V, noise amplitude = {self.amplitude:.3g}V, bandwidth = {self.norm / units.MHz:.0f}MHz")
         logger.info(f"frequency range {self.min_freq / units.MHz}MHz - {self.max_freq / units.MHz}MHz")

--- a/NuRadioReco/utilities/signal_processing.py
+++ b/NuRadioReco/utilities/signal_processing.py
@@ -29,7 +29,7 @@ from NuRadioReco.detector import filterresponse
 import NuRadioReco.framework.base_trace
 
 from scipy.signal.windows import hann
-from scipy import signal, interpolate
+from scipy import signal, interpolate, integrate
 import numpy as np
 import fractions
 import decimal
@@ -573,7 +573,7 @@ def calculate_vrms_from_temperature(temperature, bandwidth=None, response=None, 
             bandwidth = bandwidth[1] - bandwidth[0]
     else:
         freqs = freqs or np.arange(0, 2500, 0.1) * units.MHz
-        bandwidth = np.trapz(np.abs(response(freqs)) ** 2, freqs)
+        bandwidth = integrate.trapezoid(np.abs(response(freqs)) ** 2, freqs)
 
     return (temperature * impedance * bandwidth * constants.k_B) ** 0.5
 

--- a/documentation/source/NuRadioMC/pages/HDF5_structure.rst
+++ b/documentation/source/NuRadioMC/pages/HDF5_structure.rst
@@ -98,7 +98,7 @@ The station-level attributes can be accessed using ``f[station_<station_id>].att
         Key | Description
         ``Vrms`` | RMS of the voltage used as thermal noise floor :math:`v_{n} = (k_{B} \, R \, T \, \Delta f) ^ {0.5}`. See the relevant section "Maximum transfer of noise power" in this `wiki article <https://en.wikipedia.org/wiki/Johnson%E2%80%93Nyquist_noise>`_ . Determine from ``Tnoise`` and ``bandwidth`` (see below).
         ``Vrms_trigger`` | (Optional) Same as ``Vrms`` but for the trigger channels if they were simulated with a different response.
-        ``bandwidth`` | Bandwidth is above equation. Calculated as the integral over the simulated filter response (`filt`) squared: :math:`\Delta f = np.trapz(np.abs(filt) ** 2, ff)`.
+        ``bandwidth`` | Bandwidth is above equation. Calculated as the integral over the simulated filter response (`filt`) squared: :math:`\Delta f = np.trapezoid(np.abs(filt) ** 2, ff)`.
         ``antenna_positions`` | Relative position of all simulated antennas (channels)
 
 HDF5 file contents


### PR DESCRIPTION
`np.trapz` is being deprecated in favour of `np.trapezoid`, and seems to be fully removed in the latest versions of numpy. Because `np.trapezoid` is not available in some older versions of numpy, I've instead replaced it with `scipy.integrate.trapezoid` which should work on all Python versions that we claim to support.