### PR TITLE
Fix bug in SimpleIceModel.get_gradient_of_index_of_refraction - bug o…

### DIFF
--- a/NuRadioMC/utilities/medium_base.py
+++ b/NuRadioMC/utilities/medium_base.py
@@ -230,10 +230,6 @@ class IceModelSimple(IceModel):
 
         Parameters
         ----------
-        z_air_boundary: float, NuRadio length units
-            z coordinate of the surface of the glacier
-        z_bottom: float, NuRadio length units
-            z coordinate of the bedrock/bottom of the glacier.
         n_ice: float, dimensionless
             refractive index of the deep bulk ice
         delta_n: float, NuRadio length units
@@ -243,6 +239,10 @@ class IceModelSimple(IceModel):
             scale depth of the exponential
         z_shift: float, NuRadio length units
             up or down shift od the exponential profile
+        z_air_boundary: float, NuRadio length units
+            z coordinate of the surface of the glacier
+        z_bottom: float, NuRadio length units
+            z coordinate of the bedrock/bottom of the glacier.
         """
 
         super().__init__(z_air_boundary, z_bottom)
@@ -336,14 +336,14 @@ class IceModelSimple(IceModel):
         def gradient_z(z):
             return -self.delta_n / self.z_0 * np.exp((z - self.z_shift) / self.z_0)
 
-        if (isinstance(position, list) or position.ndim == 1):
-            gradient = np.array([0,0,0])
+        if isinstance(position, list) or position.ndim == 1:
+            gradient = np.array([0, 0, 0], dtype=float)
             if (position[2] - self.z_air_boundary) <= 0:
                 gradient[2] = gradient_z(position[2])
         else:
-            gradient = gradient_z(position[:,2])
+            gradient = gradient_z(position[:, 2])
             gradient[position[:, 2] - self.z_air_boundary > 0] = 0
-            gradient = np.stack((np.zeros_like(gradient),np.zeros_like(gradient),gradient),axis=1)
+            gradient = np.stack((np.zeros_like(gradient), np.zeros_like(gradient), gradient), axis=1)
 
         return gradient
 


### PR DESCRIPTION
…nly occurred when passing single position (1-dim array)

Addressing #1061 

The bug only occurs when passing a 1-d array describing a single 3-coordinate position to the function: 
```
n_grad = ice_simple.get_gradient_of_index_of_refraction(pos)  # <--- This was always fine
n_grad2 = np.array([ice_simple.get_gradient_of_index_of_refraction(np.array([0, 0, z_i])) for z_i in z])  # <--- here was the bug
```
 
This is the plots before and after fixing the issue:
<img width="1249" height="933" alt="image" src="https://github.com/user-attachments/assets/4f1c5e24-5492-4515-af32-44f6829778dc" />
<img width="1249" height="933" alt="image" src="https://github.com/user-attachments/assets/2319a54f-d6d6-4581-a378-82c962f70e4b" />

Thanks for the bug report @colemanalan.

I do not see any call of `get_gradient_of_index_of_refraction` inside any raytracing code in NuRadio. Is it safe to assume that this bug had no consequences on physics results? 

In any case I am tagging a few people so that they are aware of this bug: @sjoerd-bouma, @philippwindischhofer, @avijai2000, @mcb28 

