### PR TITLE
Fix simulation of non-trigger channels when simulating secondaries

### DIFF
--- a/NuRadioMC/simulation/simulation.py
+++ b/NuRadioMC/simulation/simulation.py
@@ -1642,16 +1642,18 @@ class simulation:
                             event_time=self._evt_time,
                             detector_simulation_part1=self.detector_simulation_part1)
 
-                        logger.debug(f"Adding sim_station to station {station_id} for event group "
-                                     f"{event_group.get_run_number()}, channel {channel_id}")
-                        station.add_sim_station(sim_station)  # this will add the channels and efields to the existing sim_station object
-
                         # The non-triggered channels were simulated using the efieldToVoltageConverterPerEfield
                         # (notice the "PerEfield" in the name). This means that each electric field was converted to
                         # a sim channel. Now we still have to add together all sim channels associated with one "physical"
                         # channel. Furthermore we have to cut out the correct readout window. For the trigger channels
                         # this is done with the channelReadoutWindowCutter, here we have to do it manually.
                         for evt in output_buffer[station_id].values():
+                            station = evt.get_station()
+
+                            logger.debug(f"Adding sim_station to station {station_id} for event group "
+                                        f"{event_group.get_run_number()}, channel {channel_id}")
+                            station.add_sim_station(sim_station)  # this will add the channels and efields to the existing sim_station object
+
                             for sim_channel in sim_station.get_channels_by_channel_id(channel_id):
                                 if not station.has_channel(sim_channel.get_id()):
                                     # For each physical channel we first create a "empty" trace (all zeros)
@@ -1662,6 +1664,10 @@ class simulation:
                                 # ... and now add the sim channel to the correct window defined by the "empty trace"
                                 # At this point the traces are noiseless, hence, we do not have to raise an error.
                                 channel.add_to_trace(sim_channel, raise_error=False)
+
+                # The signal simulation is finished, now we only have to add noise
+                # to the non-trigger channels, calculate some quatities (for convinience)
+                # and write the output.
 
                 for evt in output_buffer[station_id].values():
                     station = evt.get_station()

--- a/changelog.txt
+++ b/changelog.txt
@@ -14,6 +14,8 @@ from the NOAA ETOPO1 dataset via www.opentopodata.org.
   uneffected.
 
 bugfixes:
+- Fixing bug in the simulation of non-trigger channels when an event is splitted into multiple events based on the signal arrival time.
+  This is only relevant when simulating primaries and large detector arrays.
 
 deprecations:
 - Remove default values for `use_channels` and `bandpass` in voltageToAnalyticEfieldConverter.py and voltageToEfieldConverter.py which were suitable for ARIANNA.
@@ -41,7 +43,7 @@ new features:
 - Refactor phased array trigger modules and expands to three trigger modules, phasedArrayTrigger is the legacy trigger with a simple
   interface, beamformedPowerIntegrationTrigger performs the same function as phasedArrayTrigger but access to lower level options to mimic firmware,
   digitalBeamformedEnvelopeTrigger instead computes the Hilbert envelope of the beamformed traces and allows access to lower level options.
-- Refactor rno-g channelGlitchDector module such that `unscrable` and `diff_sq` now live outside of class definition 
+- Refactor rno-g channelGlitchDector module such that `unscrable` and `diff_sq` now live outside of class definition
   and can be called without class object.
 - Added analytic VPol and HPol antenna model approximations
 


### PR DESCRIPTION
Before the signals of non-trigger channels were only added to the station of the last event (when `group_into_events` created several events).

Thanks @Gursharan2803 for spotting it!