### PR TITLE
Update GitHub actions & fix Python environment caching

### DIFF
--- a/.github/actions/cache-ci-data/action.yml
+++ b/.github/actions/cache-ci-data/action.yml
@@ -10,7 +10,7 @@ runs:
   using: 'composite'
   steps:
     - name: Cache CI data
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           NuRadioReco/examples/Interactive/data

--- a/.github/actions/cache-ci-data/action.yml
+++ b/.github/actions/cache-ci-data/action.yml
@@ -15,4 +15,5 @@ runs:
         path: |
           NuRadioReco/examples/Interactive/data
           NuRadioReco/test/data
+          NuRadioReco/detector/AntennaModels
         key: ${{ inputs.cache-key }}

--- a/.github/actions/setup-python-env/action.yml
+++ b/.github/actions/setup-python-env/action.yml
@@ -8,6 +8,9 @@ inputs:
   cache-key:
     description: 'Cache key for Python environment'
     required: true
+  restore-only:
+    description: 'If true, only restore from cache (i.e. never saves/overwrites the cache)'
+    default: true
 
 runs:
   using: 'composite'
@@ -20,15 +23,24 @@ runs:
 
     - name: Cache Python environment
       id: cache
+      if: inputs.restore-only != 'true'
       uses: actions/cache@v5
       with:
         path: |
-          ~/.cache/pip
+          ${{ env.pythonLocation }}
+        key: ${{ inputs.cache-key }}
+
+    - name: Cache Python environment (restore only)
+      id: cache-restore
+      if: inputs.restore-only == 'true'
+      uses: actions/cache/restore@v5
+      with:
+        path: |
           ${{ env.pythonLocation }}
         key: ${{ inputs.cache-key }}
 
     - name: Install Python dependencies
-      if: steps.cache.outputs.cache-hit != 'true'
+      if: ${{ steps.cache.outputs.cache-hit != 'true' || steps.cache-restore.outputs.cache-hit != 'true' }}
       shell: bash
       run: |
         python -m pip install --upgrade pip

--- a/.github/actions/setup-python-env/action.yml
+++ b/.github/actions/setup-python-env/action.yml
@@ -16,15 +16,24 @@ runs:
       uses: actions/setup-python@v6
       with:
         python-version: ${{ inputs.python-version }}
+        cache: 'pip'
 
-    - name: Restore Python environment
-      uses: actions/cache/restore@v5
+    - name: Cache Python environment
+      id: cache-env
+      uses: actions/cache@v5
       with:
         path: |
           ~/.cache/pip
           ${{ env.pythonLocation }}
         key: ${{ inputs.cache-key }}
-        fail-on-cache-miss: true
+
+    - name: Install Python dependencies
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8 pytest
+        pip install -e .[proposal,galacticnoise,cr_interpolator]
 
     - name: Display installed Python modules
       shell: bash

--- a/.github/actions/setup-python-env/action.yml
+++ b/.github/actions/setup-python-env/action.yml
@@ -19,7 +19,7 @@ runs:
         cache: 'pip'
 
     - name: Cache Python environment
-      id: cache-env
+      id: cache
       uses: actions/cache@v5
       with:
         path: |

--- a/.github/actions/setup-python-env/action.yml
+++ b/.github/actions/setup-python-env/action.yml
@@ -13,17 +13,20 @@ runs:
   using: 'composite'
   steps:
     - name: Set up Python [${{ inputs.python-version }}]
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ inputs.python-version }}
 
     - name: Restore Python environment
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: |
           ~/.cache/pip
           ${{ env.pythonLocation }}
         key: ${{ inputs.cache-key }}
-        restore-keys: |
-          ${{ runner.os }}-env-${{ inputs.python-version }}-
-          ${{ runner.os }}-env-
+        fail-on-cache-miss: true
+
+    - name: Display installed Python modules
+      shell: bash
+      run: |
+        pip list

--- a/.github/actions/setup-python-env/action.yml
+++ b/.github/actions/setup-python-env/action.yml
@@ -40,7 +40,7 @@ runs:
         key: ${{ inputs.cache-key }}
 
     - name: Install Python dependencies
-      if: ${{ steps.cache.outputs.cache-hit != 'true' || steps.cache-restore.outputs.cache-hit != 'true' }}
+      if: ${{ steps.cache.outputs.cache-hit != 'true' && steps.cache-restore.outputs.cache-hit != 'true' }}
       shell: bash
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -23,16 +23,7 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: "3.10"
-    - name: Cache pip
-      uses: actions/cache@v5
-      with:
-        # This path is specific to Ubuntu
-        path: ~/.cache/pip
-        # Look to see if there is a cache hit for the corresponding requirements file
-        key: ${{ runner.os }}-pip-${{ hashFiles('NuRadioMC/test/requirements.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
-          ${{ runner.os }}-
+        cache: 'pip'
 
     - name: Install poetry
       run: |

--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -14,17 +14,17 @@ jobs:
 
     steps:
     - name: Get the master branch (for checks)
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ref: 'refs/heads/master'
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set up Python 3.10
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.10"
     - name: Cache pip
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         # This path is specific to Ubuntu
         path: ~/.cache/pip

--- a/.github/workflows/deploy_documentation.yaml
+++ b/.github/workflows/deploy_documentation.yaml
@@ -19,17 +19,8 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.10"
+          cache: 'pip'
 
-      - name: Cache pip
-        uses: actions/cache@v5
-        with:
-          # This path is specific to Ubuntu
-          path: ~/.cache/pip
-          # Look to see if there is a cache hit for the corresponding requirements file
-          key: ${{ runner.os }}-pip-${{ hashFiles('NuRadioMC/test/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-            ${{ runner.os }}-
       - name: Install dependencies
         run: |
           sudo apt-get install libgsl-dev

--- a/.github/workflows/deploy_documentation.yaml
+++ b/.github/workflows/deploy_documentation.yaml
@@ -11,17 +11,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4 # get the develop branch
+      - uses: actions/checkout@v6 # get the develop branch
         with:
           ref: 'refs/heads/develop'
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python 3.10
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
 
       - name: Cache pip
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           # This path is specific to Ubuntu
           path: ~/.cache/pip

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -42,10 +42,10 @@ jobs:
       data-cache-key: ${{ steps.cache-keys.outputs.data-key }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set up Python [${{ env.PYTHON_VERSION }}]
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ env.PYTHON_VERSION }}
 
@@ -57,7 +57,7 @@ jobs:
 
     - name: Cache Python environment
       id: cache-env
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/.cache/pip
@@ -94,7 +94,7 @@ jobs:
     needs: setup
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Setup GSL
       uses: ./.github/actions/setup-gsl
@@ -136,7 +136,7 @@ jobs:
     needs: setup
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Setup GSL
       uses: ./.github/actions/setup-gsl
@@ -173,7 +173,7 @@ jobs:
     needs: setup
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Setup GSL
       uses: ./.github/actions/setup-gsl
@@ -205,7 +205,7 @@ jobs:
     needs: setup
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Setup GSL
       uses: ./.github/actions/setup-gsl
@@ -242,7 +242,7 @@ jobs:
     needs: setup
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Setup GSL
       uses: ./.github/actions/setup-gsl
@@ -288,7 +288,7 @@ jobs:
     needs: setup
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Setup GSL
       uses: ./.github/actions/setup-gsl

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -44,37 +44,17 @@ jobs:
     steps:
     - uses: actions/checkout@v6
 
-    - name: Set up Python [${{ env.PYTHON_VERSION }}]
-      uses: actions/setup-python@v6
-      with:
-        python-version: ${{ env.PYTHON_VERSION }}
-
     - name: Generate cache keys
       id: cache-keys
       run: |
         echo "env-key=${{ runner.os }}-env-${{ env.PYTHON_VERSION }}-${{ hashFiles('setup.py', 'pyproject.toml') }}-v3" >> $GITHUB_OUTPUT
         echo "data-key=ci-data" >> $GITHUB_OUTPUT
 
-    - name: Cache Python environment
-      id: cache-env
-      uses: actions/cache@v5
+    - name: Set up Python and install dependencies
+      uses: ./.github/actions/setup-python-env
       with:
-        path: |
-          ~/.cache/pip
-          ${{ env.pythonLocation }}
-        key: ${{ steps.cache-keys.outputs.env-key }}
-        restore-keys: |
-          ${{ runner.os }}-env-${{ env.PYTHON_VERSION }}-
-          ${{ runner.os }}-env-
-
-    - name: Install Python dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install flake8 pytest
-        pip install -e .[proposal,galacticnoise,cr_interpolator]
-
-    - name: Display Python version
-      run: python -c "import sys; print(sys.version)"
+        python-version: ${{ env.PYTHON_VERSION }}
+        cache-key: ${{ steps.cache-keys.outputs.env-key }}
 
     - name: Lint with flake8 (important)
       if: always()

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -55,6 +55,7 @@ jobs:
       with:
         python-version: ${{ env.PYTHON_VERSION }}
         cache-key: ${{ steps.cache-keys.outputs.env-key }}
+        restore-only: false
 
     - name: Lint with flake8 (important)
       if: always()


### PR DESCRIPTION
Three minor fixes/updates:
- The caching of the Python environment would occasionally fail. It was possible for the `setup` action to set up a Python environment on a different Ubuntu version than used in subsequent actions, because `ubuntu-latest` can correspond to different Ubuntu versions. But caches (by default) are different across different OS versions (even if only differing by a minor update), which would result in a cache miss on some of the unit tests, which then would not have NuRadioMC installed. I fixed this by including a step to install NuRadioMC (`pip install -e .`) in case of a cache miss.
- I updated the marketplace github actions to the latest versions, as the versions we were using will be deprecated soon and stop working;
- I included the antenna models in the CI cache. If we're going to constantly request the same files from a server, it might as well be Microsoft's rather than DESY's.