### PR TITLE
[RNO-G glitch detector] ignore first block

### DIFF
--- a/NuRadioReco/modules/RNO_G/channelGlitchDetector.py
+++ b/NuRadioReco/modules/RNO_G/channelGlitchDetector.py
@@ -143,6 +143,7 @@ def unscramble(trace, block_size=LAB4D_SAMPLING_BLOCK_SIZE, readout_size=LAB4D_R
 def diff_sq(eventdata, block_size=LAB4D_SAMPLING_BLOCK_SIZE):
     """
     Returns sum of squared differences of samples across seams of 128-sample chunks.
+    Ignores the first and last `block_size` samples, which `unscramble` cannot reconstruct.
 
     Parameters
     ----------
@@ -152,7 +153,7 @@ def diff_sq(eventdata, block_size=LAB4D_SAMPLING_BLOCK_SIZE):
     twice_block_size = 2 * block_size
 
     runsum = 0.0
-    for chunk in range(len(eventdata) // twice_block_size - 1):
+    for chunk in range(1, len(eventdata) // twice_block_size - 1):
         runsum += (eventdata[chunk * twice_block_size + block_size - 1] - eventdata[chunk * twice_block_size + block_size]) ** 2
     return np.sum(runsum)
 


### PR DESCRIPTION
Small change to also ignore the first block, as discussed with @fschlueter. The last block was already ignored.

Verified that this leads to insignificant changes in the glitch detector output, shown below for station 11, run 683.

Before this change:

<img width="1200" height="1000" alt="station11_run683_original" src="https://github.com/user-attachments/assets/d924be39-cac1-4447-a7e7-21e3d4207028" />

After this change:

<img width="1200" height="1000" alt="station11_run683_modified" src="https://github.com/user-attachments/assets/df9ec791-d634-453d-bd05-937d03b6addb" />
