### PR TITLE
[LOFAR] Setting array element with a sequence

### DIFF
--- a/NuRadioReco/modules/io/LOFAR/_rawTBBio.py
+++ b/NuRadioReco/modules/io/LOFAR/_rawTBBio.py
@@ -308,7 +308,7 @@ class TBBData_Dal1:
             for i, dipole in enumerate(self.dipoleNames):
                 self.calibrationDelays[i] = self.file[self.stationKey][dipole].attrs[
                     "DIPOLE_CALIBRATION_DELAY_VALUE"
-                ]
+                ][0]
 
         # get the offset, in number of samples, needed so that each antenna starts at the same time #
         self.nominal_sample_number = np.max(self.SampleNumbers)


### PR DESCRIPTION
Setting an array element with a sequence has been deprecated in numpy for a while, and has started raising an error with numpy 2.4. For some reason, it seems the "DIPOLE_CALIBRATION_DELAY_VALUE" in the raw TBB files is an array with shape (1,) instead of a single float, so this raises an error (see https://github.com/nu-radio/NuRadioMC/actions/runs/23240232748/job/67555126162). This simply reads out the first entry to fix that.

Maybe someone who's looked at more LOFAR data can confirm if this works consistently for older/newer lofar files also (i.e. that this "DIPOLE_CALIBRATION_VALUE" is always an array and never a float). But on the example file this seems to fix the issue (see https://github.com/nu-radio/NuRadioMC/actions/runs/23447696208/job/68216002463).