### PR TITLE
Fix ModDetector - remnant from replacing signal_chain dict to list

### DIFF
--- a/NuRadioReco/detector/RNO_G/rnog_detector_mod.py
+++ b/NuRadioReco/detector/RNO_G/rnog_detector_mod.py
@@ -74,10 +74,10 @@ class ModDetector(Detector):
     @_check_detector_time
     def get_channel(self, station_id, channel_id):
         """
-        Returns a dictionary of all channel parameters. 
-        
-        The dictionary is returned as a "reference" (as every mutable object in python, without a copy call). 
-        That means, changing entries in this dictionary will change the detector description in memory. 
+        Returns a dictionary of all channel parameters.
+
+        The dictionary is returned as a "reference" (as every mutable object in python, without a copy call).
+        That means, changing entries in this dictionary will change the detector description in memory.
 
         Parameters
         ----------
@@ -187,7 +187,7 @@ class ModDetector(Detector):
 
         # modify the signal chain
         signal_chain_dict["total_response"] = orig_response * component_response
-        signal_chain_dict["response_chain"][component['name']] = component
+        signal_chain_dict["response_chain"].append(component)
 
         # write the modified signal chain back to the buffered station
         self._Detector__buffered_stations[station_id]["channels"][channel_id]['signal_chain'] = signal_chain_dict


### PR DESCRIPTION
This fix enables (again) to change the cable delay of our detector. Remnant from when we changed the data type of the signal chain "collection" from a dict to a list.