### PR TITLE
reco3d: force uproot mattak backend for ROOT inputs

### DIFF
--- a/NuRadioReco/examples/RNOG/interferometric_reco_ex/interferometric_reco_3d_example.py
+++ b/NuRadioReco/examples/RNOG/interferometric_reco_ex/interferometric_reco_3d_example.py
@@ -533,7 +533,8 @@ def main():
         else:
             reader = readRNOGData()
             reader.begin(input_file,
-                         mattak_kwargs={'read_daq_status': False})
+                         mattak_kwargs={'read_daq_status': False,
+                                        'backend': 'uproot'})
             event_ids = reader.get_event_ids()
 
         emitter_pos = None


### PR DESCRIPTION
## Summary
Add `'backend': 'uproot'` to the existing `mattak_kwargs` dict passed to `readRNOGData.begin()` in `interferometric_reco_3d_example.py`.

## Why
The default pyroot backend segfaults on `d.wfs()` inside apptainer containers built on `rootproject/root:6.32` with pip-installed numpy 2.1. The crash is in `numpy/_core/_multiarray_umath.so` and reproduces with numpy binaries byte-identical to a working host install, so it is not a trivial ABI mismatch. Uproot is pure Python and works in the same container.

## Verification
Reco smoke test on two real RNO-G burn sample runs inside the affected container: 8 events processed, 0.63 s/evt, no segfault.

## Test plan
- [ ] CI on reco3d_release
- [ ] Rerun downstream RNO-G Snakemake pipeline on ROOT inputs