### PR TITLE
Hotfix: pin pygdsm on Python versions <3.9

### DIFF
--- a/.github/workflows/deploy_documentation.yaml
+++ b/.github/workflows/deploy_documentation.yaml
@@ -22,6 +22,7 @@ jobs:
           cache: 'pip'
 
       - name: Install dependencies
+        timeout-minutes: 20
         run: |
           sudo apt-get install libgsl-dev
           python -m pip install --upgrade pip

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -78,6 +78,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Setup GSL
+      timeout-minutes: 5
       uses: ./.github/actions/setup-gsl
 
     - name: Setup Python Environment
@@ -120,6 +121,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Setup GSL
+      timeout-minutes: 5
       uses: ./.github/actions/setup-gsl
 
     - name: Setup Python Environment
@@ -157,6 +159,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Setup GSL
+      timeout-minutes: 5
       uses: ./.github/actions/setup-gsl
 
     - name: Setup Python Environment
@@ -189,6 +192,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Setup GSL
+      timeout-minutes: 5
       uses: ./.github/actions/setup-gsl
 
     - name: Setup Python Environment
@@ -226,6 +230,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Setup GSL
+      timeout-minutes: 5
       uses: ./.github/actions/setup-gsl
 
     - name: Setup Python Environment
@@ -272,6 +277,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Setup GSL
+      timeout-minutes: 5
       uses: ./.github/actions/setup-gsl
 
     - name: Setup Python Environment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,8 +47,9 @@ sphinx-rtd-theme = {version = "*", optional = true}
 numpydoc = {version = "*", optional = true}
 proposal = {version = "7.6.2", optional = true}
 pylfmap = {version = "*", optional = true}
-pygdsm = {version = "<1.7", optional = true, python = "<3.9"}
-pygdsm = {version = "*", optional = true, python = ">=3.9"}
+pygdsm = [
+    {version = "<1.7", optional = true, python = "<3.9"},
+    {version = "*", optional = true, python = ">=3.9"}]
 healpy = {version = "*", optional = true}
 MCEq = {version = "*", optional = true}
 crflux = {version = "*", optional = true}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,8 @@ sphinx-rtd-theme = {version = "*", optional = true}
 numpydoc = {version = "*", optional = true}
 proposal = {version = "7.6.2", optional = true}
 pylfmap = {version = "*", optional = true}
-pygdsm = {version = "*", optional = true}
+pygdsm = {version = "<1.7", optional = true, python = "<3.9"}
+pygdsm = {version = "*", optional = true, python = ">=3.9"}
 healpy = {version = "*", optional = true}
 MCEq = {version = "*", optional = true}
 crflux = {version = "*", optional = true}


### PR DESCRIPTION
The most recent pygdsm release (1.7.0) no longer works on Python 3.7/3.8, but did not update the minimum Python version required (yet). This PR just pins it to the older version which still works for the older Python versions, which doesn't change anything for the newer Python versions.

I also noticed a couple of `setup GSL` jobs timing out on the most recent CI run, taking 6 hours before giving up. That seems an excessive amount of compute time to spend waiting for a confused server; I've changed the timeout for this step to 5 minutes instead (when it completes successfully it usually takes O(8 s) so this should be plenty).