### PR TITLE
CI: add timeout to GSL setup step

### DIFF
--- a/.github/workflows/deploy_documentation.yaml
+++ b/.github/workflows/deploy_documentation.yaml
@@ -22,6 +22,7 @@ jobs:
           cache: 'pip'
 
       - name: Install dependencies
+        timeout-minutes: 20
         run: |
           sudo apt-get install libgsl-dev
           python -m pip install --upgrade pip

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -78,6 +78,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Setup GSL
+      timeout-minutes: 5
       uses: ./.github/actions/setup-gsl
 
     - name: Setup Python Environment
@@ -120,6 +121,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Setup GSL
+      timeout-minutes: 5
       uses: ./.github/actions/setup-gsl
 
     - name: Setup Python Environment
@@ -157,6 +159,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Setup GSL
+      timeout-minutes: 5
       uses: ./.github/actions/setup-gsl
 
     - name: Setup Python Environment
@@ -189,6 +192,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Setup GSL
+      timeout-minutes: 5
       uses: ./.github/actions/setup-gsl
 
     - name: Setup Python Environment
@@ -226,6 +230,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Setup GSL
+      timeout-minutes: 5
       uses: ./.github/actions/setup-gsl
 
     - name: Setup Python Environment
@@ -272,6 +277,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Setup GSL
+      timeout-minutes: 5
       uses: ./.github/actions/setup-gsl
 
     - name: Setup Python Environment


### PR DESCRIPTION
I noticed a couple of setup GSL jobs timing out on a recent CI run, taking 6 hours before giving up. That seems an excessive amount of compute time to spend waiting for a confused server; I've changed the timeout for this step to 5 minutes instead (when it completes successfully it usually takes O(8 s) so this should be plenty).