### PR TITLE
Add 'header' to string type attributes list

### DIFF
--- a/NuRadioMC/utilities/merge_hdf5.py
+++ b/NuRadioMC/utilities/merge_hdf5.py
@@ -10,7 +10,7 @@ import logging
 import math
 logger = logging.getLogger("NuRadioMC.HDF5-merger")
 
-str_type_attrs = ['trigger_names', 'NuRadioMC_EvtGen_version', 'NuRadioMC_EvtGen_version_hash', 'NuRadioMC_version', 'NuRadioMC_version_hash', 'config']
+str_type_attrs = ['trigger_names', 'NuRadioMC_EvtGen_version', 'NuRadioMC_EvtGen_version_hash', 'NuRadioMC_version', 'NuRadioMC_version_hash', 'config', 'header']
 
 
 def merge2(filenames, output_filename):


### PR DESCRIPTION
If no events trigger, the file can also end up with a copy of the `header` object from the input file generator. In which case, we want to allow that to go in the merge, or else things crash with an ugly error, which looks like this

```
numpy.exceptions.DTypePromotionError: The DType <class 'numpy.dtypes.StrDType'> could not be promoted by <class 'numpy.dtypes._PyFloatDType'>. This means that no common DType exists for the given inputs. For example they cannot be stored in a single array unless the dtype is `object`. The full list of DTypes is: (<class 'numpy.dtypes.StrDType'>, <class 'numpy.dtypes._PyFloatDType'>)

```