### PR TITLE
Fix: pass missing station and channel IDs to Response in hardwareResp…

### DIFF
--- a/NuRadioReco/modules/RNO_G/hardwareResponseIncorporator.py
+++ b/NuRadioReco/modules/RNO_G/hardwareResponseIncorporator.py
@@ -101,7 +101,7 @@ class hardwareResponseIncorporator:
             # it reads the log file. change this to load_amp_measurement if you want the RI file
             amp_response = analog_components.load_amp_response(amp_type)
             response_list = [amp_response['gain'](frequencies, temp), np.angle(amp_response['phase'](frequencies))]
-            amp_response = response.Response(frequencies, response_list, ["mag", "rad"])
+            amp_response = response.Response(frequencies, response_list, ["mag", "rad"], station_id=station_id, channel_id=channel_id)
         else:
             raise NotImplementedError("Detector type not implemented")
 


### PR DESCRIPTION
# The problem

When simulating with:

```python

class mySimulation(simulation.simulation):

    def __init__(self, threshold=1.0, trig_chan=0, **kwargs):
        # init code
    def _detector_simulation_filter_amp(self, evt, station, det):
        hardware_response.run(evt, station, det, sim_to_data=True)

    def _detector_simulation_trigger(self, evt, station, det):
        # trigger code

if __name__ == "__main__":
    sim = mySimulation(detectorfile='path_to_json_file', kwargs*)
    sim.run()
```

I get the following error:

`"Station and channel id were not defined for response default. Please do that."`

I traced this to line 101 of `NuRadioMC/NuRadioReco/detector/response.py`:

```python
if self._station_id is None or self._channel_id is None and self._station_id != -1:
    self.logger.error(f"Station and channel id were not defined for response {name}. Please do that.")
```

Taking one step back, the problem seems to be in `NuRadioMC/NuRadioReco/modules/RNO_G/hardwareResponseIncorporator.py`, which is the class I use in my simulation. On line 104:

```python
if isinstance(det, detector.rnog_detector.Detector):
            amp_response = det.get_signal_chain_response(station_id, channel_id, is_trigger)
        elif isinstance(det, detector.detector_base.DetectorBase):
            amp_type = det.get_amplifier_type(station_id, channel_id)
            # it reads the log file. change this to load_amp_measurement if you want the RI file
            amp_response = analog_components.load_amp_response(amp_type)
            response_list = [amp_response['gain'](frequencies, temp), np.angle(amp_response['phase'](frequencies))]
            amp_response = response.Response(frequencies, response_list, ["mag", "rad"]) <--- ISSUE IS HERE
        else:
            raise NotImplementedError("Detector type not implemented")
```

If the detector is not an `rnog_detector.Detector` instance, then the `elif` triggers and in amp_response, no channel or station id are passed, causing them to be `None`. Im not sure if this is the intended functionality as I am not familiar with how to calculate the hardware response with a generic detector, but I wanted to bring awareness to this just in case.

# The Fix:

If this is indeed not intended, simply update line 104 to pass in the channel and station ids.