### PR TITLE
_calculate_time_delay function doesn't exist for the Response() class

### DIFF
--- a/NuRadioReco/detector/RNO_G/rnog_detector.py
+++ b/NuRadioReco/detector/RNO_G/rnog_detector.py
@@ -1445,7 +1445,7 @@ class Detector():
                                     log_level=self.__log_level)
 
                 weight = component_dic.get("weight", 1)
-                time_delay += weight * response._calculate_time_delay()
+                time_delay += weight * response.calculate_time_delay()
 
         return time_delay
 

--- a/NuRadioReco/detector/RNO_G/rnog_detector_mod.py
+++ b/NuRadioReco/detector/RNO_G/rnog_detector_mod.py
@@ -278,7 +278,7 @@ if __name__ == "__main__":
     import datetime
     det.update(datetime.datetime(2023, 1, 1, 0, 0, 0))
     resp = det.get_signal_chain_response(11, 0)
-    print(resp.get_time_delay(), resp._calculate_time_delay())
+    print(resp.get_time_delay(), resp.calculate_time_delay())
     det.add_manual_time_delay(11, 0, 250)
     resp = det.get_signal_chain_response(11, 0)
-    print(resp.get_time_delay(), resp._calculate_time_delay())
+    print(resp.get_time_delay(), resp.calculate_time_delay())


### PR DESCRIPTION
`_calculate_time_delay` function doesn't exist for the `Response()` class, changed it to `calculate_time_delay`
