### PR TITLE
[CI] Improve caching

### DIFF
--- a/.github/actions/cache-ci-data/action.yml
+++ b/.github/actions/cache-ci-data/action.yml
@@ -16,4 +16,5 @@ runs:
           NuRadioReco/examples/Interactive/data
           NuRadioReco/test/data
           NuRadioReco/detector/AntennaModels
+          NuRadioMC/utilities/data/*.npz
         key: ${{ inputs.cache-key }}

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -87,6 +87,11 @@ jobs:
         python-version: ${{ env.PYTHON_VERSION }}
         cache-key: ${{ needs.setup.outputs.env-cache-key }}
 
+    - name: Cache CI Data
+      uses: ./.github/actions/cache-ci-data
+      with:
+        cache-key: ${{ needs.setup.outputs.data-cache-key }}-${{ github.job }}
+
     - name: "Validate separate trigger channels"
       if: always()
       run: |
@@ -130,6 +135,11 @@ jobs:
         python-version: ${{ env.PYTHON_VERSION }}
         cache-key: ${{ needs.setup.outputs.env-cache-key }}
 
+    - name: Cache CI Data
+      uses: ./.github/actions/cache-ci-data
+      with:
+        cache-key: ${{ needs.setup.outputs.data-cache-key }}-${{ github.job }}
+
     - name: Signal generation test
       if: always()
       run : |
@@ -167,6 +177,11 @@ jobs:
       with:
         python-version: ${{ env.PYTHON_VERSION }}
         cache-key: ${{ needs.setup.outputs.env-cache-key }}
+    
+    - name: Cache CI Data
+      uses: ./.github/actions/cache-ci-data
+      with:
+        cache-key: ${{ needs.setup.outputs.data-cache-key }}-${{ github.job }}
 
     - name: "Veff test"
       if: always()
@@ -204,7 +219,7 @@ jobs:
     - name: Cache CI Data
       uses: ./.github/actions/cache-ci-data
       with:
-        cache-key: ${{ needs.setup.outputs.data-cache-key }}
+        cache-key: ${{ needs.setup.outputs.data-cache-key }}-${{ github.job }}
 
     - name: "RNO-G Detector"
       if: always()
@@ -238,6 +253,12 @@ jobs:
       with:
         python-version: ${{ env.PYTHON_VERSION }}
         cache-key: ${{ needs.setup.outputs.env-cache-key }}
+  
+    - name: Cache CI Data
+      uses: ./.github/actions/cache-ci-data
+      with:
+        cache-key: ${{ needs.setup.outputs.data-cache-key }}-${{ github.job }}
+
 
     - name: "channelGalacticNoiseAdder"
       if: always()
@@ -289,7 +310,7 @@ jobs:
     - name: Cache CI Data
       uses: ./.github/actions/cache-ci-data
       with:
-        cache-key: ${{ needs.setup.outputs.data-cache-key }}
+        cache-key: ${{ needs.setup.outputs.data-cache-key }}-${{ github.job }}
 
     - name: "Test Veff example"
       if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,17 @@
 !*reference*.nur
 !*reference*.hdf5
 
+# other binary storage files
+*.gz
+*.xz
+*.zip
+*.bz
+*.lzma
+*.tar
+*.npz
+*.npy
+*.root
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
It seems DESY has become a bit stricter on how many downloads it's providing to a single user, leading to our CI failing because of downloads timing out. There is a discussion going on there to try to find a solution, but in the meantime, this should improve our caching (only one job had properly cached downloads previously).

Something else I realised while looking into this is that if we ever modify the workflow, e.g. by adding additional tests that require additional files, these will never be included in the cache automatically (because the old cache is not overwritten on a cache hit). [This](https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache) would be a possible solution, but seems somewhat inelegant to me because it will rapidly fill the cache quota for no reason. The alternative is manually (or automatically) clearing the cache whenever the github workflow changes.