### PR TITLE
[hotfix] add missing precalculated parameter for white noise

### DIFF
--- a/NuRadioReco/modules/channelGenericNoiseAdder.py
+++ b/NuRadioReco/modules/channelGenericNoiseAdder.py
@@ -25,7 +25,7 @@ class channelGenericNoiseAdder:
         n_samples_time_domain: int
             number of samples in the time domain to differentiate between odd and even number of samples
         """
-        amps = np.asarray(amps, dtype='complex')
+        amps = np.array(amps, dtype='complex')
         Np = (n_samples_time_domain - 1) // 2
         phases = self.__random_generator.random(Np) * 2 * np.pi
         phases = np.cos(phases) + 1j * np.sin(phases)
@@ -167,7 +167,8 @@ class channelGenericNoiseAdder:
         """
         Precalculate parameters for bandlimited noise.
 
-        Precalculate some parameters to use 
+        Precalculate some parameters to use to generate noise using the 
+        `bandlimited_noise_from_precalculated_parameters`.
 
         Parameters
         ----------
@@ -255,7 +256,6 @@ class channelGenericNoiseAdder:
         Generate noise using previously set parameters
         
         Generates noise using parameters pre-set using `precalculate_bandlimited_noise_parameters`.
-        Only the noise type can 
 
         Parameters
         ----------

--- a/NuRadioReco/modules/channelGenericNoiseAdder.py
+++ b/NuRadioReco/modules/channelGenericNoiseAdder.py
@@ -4,6 +4,7 @@ from scipy import integrate
 from numpy.random import Generator, Philox
 from NuRadioReco.utilities import units, fft
 from NuRadioReco.modules.base.module import register_run
+import warnings
 
 
 class channelGenericNoiseAdder:
@@ -12,7 +13,6 @@ class channelGenericNoiseAdder:
 
 
     """
-
     def add_random_phases(self, amps, n_samples_time_domain):
         """
         Adding random phase information to given amplitude spectrum.
@@ -25,15 +25,20 @@ class channelGenericNoiseAdder:
         n_samples_time_domain: int
             number of samples in the time domain to differentiate between odd and even number of samples
         """
-        amps = np.array(amps, dtype='complex')
+        amps = np.asarray(amps, dtype='complex')
         Np = (n_samples_time_domain - 1) // 2
         phases = self.__random_generator.random(Np) * 2 * np.pi
         phases = np.cos(phases) + 1j * np.sin(phases)
         amps[1:Np + 1] *= phases  # Note that the last entry of the index slice is f[Np] !
 
         return amps
+    
+    def fftnoise_fullfft(self, *args, **kwargs):
+        """Deprecated"""
+        warnings.warn("The 'fftnoise_fullfft' method will be deprecated in a future release", DeprecationWarning)
+        return self._fftnoise_fullfft(*args, **kwargs)
 
-    def fftnoise_fullfft(self, f):
+    def _fftnoise_fullfft(self, f):
         """
         Adding random phase information to given amplitude spectrum.
 
@@ -67,7 +72,7 @@ class channelGenericNoiseAdder:
     def bandlimited_noise(self, min_freq, max_freq, n_samples, sampling_rate, amplitude, type='perfect_white',
                           time_domain=True, bandwidth=None):
         """
-        Generating noise of n_samples in a bandwidth [min_freq,max_freq].
+        Generate noise of n_samples in a bandwidth [min_freq,max_freq].
 
         Parameters
         ----------
@@ -89,7 +94,6 @@ class channelGenericNoiseAdder:
         type: string
             perfect_white: flat frequency spectrum
             rayleigh: Amplitude of each frequency bin is drawn from a Rayleigh distribution
-            # white: flat frequency spectrum with random jitter
         time_domain: bool (default True)
             if True returns noise in the time domain, if False it returns the noise in the frequency domain. The latter
             might be more performant as the noise is generated internally in the frequency domain.
@@ -102,8 +106,6 @@ class channelGenericNoiseAdder:
         -----
         *   Note that by design the max frequency is the Nyquist frequency, even if a bigger max_freq
             is implemented (RL 17-Sept-2018)
-
-        *   Add 'multi_white' noise option on 20-Sept-2018 (RL)
 
         """
         frequencies = fft.freqs(n_samples, sampling_rate)
@@ -163,7 +165,9 @@ class channelGenericNoiseAdder:
             self, min_freq, max_freq, n_samples, sampling_rate, amplitude,
             type='perfect_white', bandwidth=None):
         """
-        Generating noise of n_samples in a bandwidth [min_freq,max_freq].
+        Precalculate parameters for bandlimited noise.
+
+        Precalculate some parameters to use 
 
         Parameters
         ----------
@@ -185,7 +189,6 @@ class channelGenericNoiseAdder:
         type: string
             perfect_white: flat frequency spectrum
             rayleigh: Amplitude of each frequency bin is drawn from a Rayleigh distribution
-            # white: flat frequency spectrum with random jitter
         time_domain: bool (default True)
             if True returns noise in the time domain, if False it returns the noise in the frequency domain. The latter
             might be more performant as the noise is generated internally in the frequency domain.
@@ -199,8 +202,10 @@ class channelGenericNoiseAdder:
         *   Note that by design the max frequency is the Nyquist frequency, even if a bigger max_freq
             is implemented (RL 17-Sept-2018)
 
-        *   Add 'multi_white' noise option on 20-Sept-2018 (RL)
-
+        See Also
+        --------
+        bandlimited_noise_from_precalculated_parameters
+        bandlimited_noise: method to generate noise without pre-calculating parameters
         """
         frequencies = np.fft.rfftfreq(n_samples, 1. / sampling_rate)
 
@@ -235,6 +240,7 @@ class channelGenericNoiseAdder:
                 "n_samples_freq": n_samples_freq,
                 "selection": selection,
                 "nbinsactive": nbinsactive,
+                "amplitude": amplitude,
                 "sigscale": sigscale,
                 "fsigma": fsigma,
                 "sampling_rate": sampling_rate,
@@ -246,43 +252,30 @@ class channelGenericNoiseAdder:
     def bandlimited_noise_from_precalculated_parameters(self, type='perfect_white',
                           time_domain=True):
         """
-        Generating noise of n_samples in a bandwidth [min_freq,max_freq].
+        Generate noise using previously set parameters
+        
+        Generates noise using parameters pre-set using `precalculate_bandlimited_noise_parameters`.
+        Only the noise type can 
 
         Parameters
         ----------
 
-        min_freq: float
-            Minimum frequency of passband for noise generation
-            min_freq = None: Only the DC component is removed. If the DC component should be included,
-            min_freq = 0 has to be specified
-        max_freq: float
-            Maximum frequency of passband for noise generation
-            If the maximum frequency is above the Nquist frequencey (0.5 * sampling rate), the Nquist frequency is used
-            max_freq = None: Frequencies up to Nyquist freq are used.
-        n_samples: int
-            number of samples in the time domain
-        sampling_rate: float
-            desired sampling rate of data
-        amplitude: float
-            desired voltage of noise as V_rms (only roughly, since bandpass limited)
         type: string
             perfect_white: flat frequency spectrum
             rayleigh: Amplitude of each frequency bin is drawn from a Rayleigh distribution
-            # white: flat frequency spectrum with random jitter
         time_domain: bool (default True)
             if True returns noise in the time domain, if False it returns the noise in the frequency domain. The latter
             might be more performant as the noise is generated internally in the frequency domain.
-        bandwidth: float or None (default)
-            if this parameter is specified, the amplitude is interpreted as the amplitude for the bandwidth specified here
-            Otherwise the amplitude is interpreted for the bandwidth of min(max_freq, 0.5 * sampling rate) - min_freq
-            If `bandwidth` is larger then (min(max_freq, 0.5 * sampling rate) - min_freq) it has the same effect as `None`
 
         Notes
         -----
         *   Note that by design the max frequency is the Nyquist frequency, even if a bigger max_freq
             is implemented (RL 17-Sept-2018)
 
-        *   Add 'multi_white' noise option on 20-Sept-2018 (RL)
+        See Also
+        --------
+        precalculate_bandlimited_noise_parameters
+        bandlimited_noise: method to generate noise without pre-calculating parameters
 
         """
 
@@ -291,15 +284,12 @@ class channelGenericNoiseAdder:
             ampl[self.precalculated_parameters["selection"]] = self.precalculated_parameters["amplitude"] * self.precalculated_parameters["sigscale"]
         elif type == 'rayleigh':
             ampl[self.precalculated_parameters["selection"]] = self.__random_generator.rayleigh(self.precalculated_parameters["fsigma"], self.precalculated_parameters["nbinsactive"])
-#         elif type == 'white':
-# FIXME: amplitude normalization is not correct for 'white'
-#             ampl = np.random.rand(n_samples) * 0.05 * amplitude + amplitude * np.sqrt(2.*n_samples * 2)
         else:
             self.logger.error("Other types of noise not yet implemented.")
             raise NotImplementedError("Other types of noise not yet implemented.")
 
         noise = self.add_random_phases(ampl, self.precalculated_parameters["n_samples"]) / self.precalculated_parameters["sampling_rate"]
-        if(time_domain):
+        if time_domain:
             return fft.freq2time(noise, self.precalculated_parameters["sampling_rate"], n=self.precalculated_parameters["n_samples"])
         else:
             return noise
@@ -308,7 +298,7 @@ class channelGenericNoiseAdder:
     def bandlimited_noise_from_spectrum(self, n_samples, sampling_rate, spectrum, amplitude=None, type='perfect_white',
                           time_domain=True):
         """
-        Generating noise of n_samples in a bandwidth [min_freq,max_freq].
+        Generate noise of n_samples in a bandwidth [min_freq,max_freq].
 
         Parameters
         ----------
@@ -317,7 +307,7 @@ class channelGenericNoiseAdder:
         sampling_rate: float
             desired sampling rate of data
         spectrum: numpy.ndarray, function
-            disired spectrum of the noise, either as a numpy.ndarray of length n_frequencies or a function
+            desired spectrum of the noise, either as a numpy.ndarray of length n_frequencies or a function
             that takes the frequencies as an argument and returns the amplitudes. The overall normalization
             of the spectrum is ignored if the paramter "amplitude" is set.
         amplitude: float, optional
@@ -326,7 +316,6 @@ class channelGenericNoiseAdder:
         type: string
             perfect_white: flat frequency spectrum
             rayleigh: Amplitude of each frequency bin is drawn from a Rayleigh distribution
-            # white: flat frequency spectrum with random jitter
         time_domain: bool (default True)
             if True returns noise in the time domain, if False it returns the noise in the frequency domain. The latter
             might be more performant as the noise is generated internally in the frequency domain.


### PR DESCRIPTION
Only one real change - added `amplitude` to the `precalculated_parameters`. The `bandlimited_noise_from_precalculated_parameters` would otherwise raise a KeyError if generating `perfect_white` noise. Found by @EnriqueHuesca / Claude. The rest is just some minor tidying up of docstrings, plus a pending deprecation of the `fftnoise_fullfft` method which is not used internally and unlikely to be used anywhere else.

I'm not convinced that the whole precalculation routine is used much or indeed useful for much, so I would also be open to just removing it altogether, but I haven't gone through the trouble of benchmarking it to check if this feeling is correct.