### PR TITLE
Weight parameter for time-dependent template response in the signal chain

### DIFF
--- a/NuRadioReco/detector/RNO_G/db_mongo_read.py
+++ b/NuRadioReco/detector/RNO_G/db_mongo_read.py
@@ -1109,6 +1109,7 @@ class Database(object):
                         template_name = component_data["template_response"]["name"]
                         component_data_template = {"collection": "full_chain"}
                         component_data_template["name"] = template_name
+                        component_data_template["weight"] = 1
                         component_data_template.update(self.get_component_data(
                             collection_name="full_chain",
                             component_name=component_data["template_response"]["name"],


### PR DESCRIPTION
Added the forgotten weight for the time-dependent template response, so that the weight is correctly assigned for the get_signal_chain_response() function in the rnog_detector.py (See PR #1043 for more)
 