### PR TITLE
Improve time logging

### DIFF
--- a/NuRadioMC/SignalProp/analyticraytracing.py
+++ b/NuRadioMC/SignalProp/analyticraytracing.py
@@ -2082,12 +2082,12 @@ class ray_tracing(ray_tracing_base):
         self._R = np.array(((c, -s, 0), (s, c, 0), (0, 0, 1)))
         X1r = self._X1
         X2r = np.dot(self._R, self._X2 - self._X1) + self._X1
-        self.__logger.debug("X1 = {}, X2 = {}".format(self._X1, self._X2))
-        self.__logger.debug('dphi = {:.1f}'.format(self._dPhi / units.deg))
-        self.__logger.debug("X2 - X1 = {}, X1r = {}, X2r = {}".format(self._X2 - self._X1, X1r, X2r))
+        self.__logger.debug("X1 = %s, X2 = %s", self._X1, self._X2)
+        self.__logger.debug("dphi = %.1f", self._dPhi / units.deg)
+        self.__logger.debug("X2 - X1 = %s, X1r = %s, X2r = %s", dX, X1r, X2r)
         self._x1 = np.array([X1r[0], X1r[2]])
         self._x2 = np.array([X2r[0], X2r[2]])
-        self.__logger.debug("2D points {} {}".format(self._x1, self._x2))
+        self.__logger.debug("2D points %s %s", self._x1, self._x2)
 
     def set_solution(self, raytracing_results):
         """

--- a/NuRadioMC/SignalProp/analyticraytracing.py
+++ b/NuRadioMC/SignalProp/analyticraytracing.py
@@ -1136,7 +1136,7 @@ class ray_tracing_2D(ray_tracing_base):
             # that will produce a downward going ray through x1
             y_turn = get_y_turn(C_0, x1, self.medium.n_ice, self.__b, self.medium.delta_n, self.medium.z_0)
             dy = y_turn - x1[0]
-            self.__logger.debug("relaction case 2: shifting x1 %s to %s", x1, x1[0] - 2 * dy)
+            self.__logger.debug("reflection case 2: shifting x1 %s to %s", x1, x1[0] - 2 * dy)
             x1[0] = x1[0] - 2 * dy
 
         segments = []
@@ -1330,7 +1330,7 @@ class ray_tracing_2D(ray_tracing_base):
             # that will produce a downward going ray through x1
             y_turn = get_y_turn(C_0, x1, self.medium.n_ice, self.__b, self.medium.delta_n, self.medium.z_0)
             dy = y_turn - x1[0]
-            self.__logger.debug("relaction case 2: shifting x1 %s to %s", x1, x1[0] - 2 * dy)
+            self.__logger.debug("reflection case 2: shifting x1 %s to %s", x1, x1[0] - 2 * dy)
             x1[0] = x1[0] - 2 * dy
 
         if(reflection == 0):

--- a/NuRadioMC/SignalProp/analyticraytracing.py
+++ b/NuRadioMC/SignalProp/analyticraytracing.py
@@ -927,7 +927,7 @@ class ray_tracing_2D(ray_tracing_base):
                 freqs = np.append(freqs, np.linspace(frequency[~det_mask].min(), frequency[~det_mask].max(), n_freqs // 2))
 
 
-        self.__logger.debug("Frequency vector for attenuation calculation: {}".format(freqs))
+        self.__logger.debug("Frequency vector for attenuation calculation: %s", freqs)
         return freqs
 
     def get_attenuation_along_path(self, x1, x2, C_0, frequency, max_detector_freq,
@@ -1136,12 +1136,12 @@ class ray_tracing_2D(ray_tracing_base):
             # that will produce a downward going ray through x1
             y_turn = get_y_turn(C_0, x1, self.medium.n_ice, self.__b, self.medium.delta_n, self.medium.z_0)
             dy = y_turn - x1[0]
-            self.__logger.debug("relaction case 2: shifting x1 {} to {}".format(x1, x1[0] - 2 * dy))
+            self.__logger.debug("relaction case 2: shifting x1 %s to %s", x1, x1[0] - 2 * dy)
             x1[0] = x1[0] - 2 * dy
 
         segments = []
         for i in range(reflection + 1):
-            self.__logger.debug("calculation path for reflection = {}".format(i + 1))
+            self.__logger.debug("calculation path for reflection = %d", i + 1)
             C_1 = self.get_C_1(x1, C_0)
             x2 = get_reflection_point(C_0, C_1, self.medium.n_ice, self.reflection, self.__b, self.medium.z_0, self.medium.delta_n)
             stop_loop = False
@@ -1153,7 +1153,7 @@ class ray_tracing_2D(ray_tracing_base):
             if stop_loop:
                 break
 
-            self.__logger.debug("setting x1 from {} to {}".format(x1, x2))
+            self.__logger.debug("setting x1 from %s to %s", x1, x2)
             x1 = x2
 
         return segments
@@ -1230,7 +1230,7 @@ class ray_tracing_2D(ray_tracing_base):
             if((z_turn >= 0) and (y_turn > x11[0]) and (y_turn < x22[0])):  # for the first track segment we need to check if turning point is right of start point (otherwise we have a downward going ray that does not have a turning point), and for the last track segment we need to check that the turning point is left of the stop position.
                 r = self.get_angle(np.array([y_turn, 0]), x1, C_0)
                 self.__logger.debug(
-                    "reflecting off surface at y = {:.1f}m, reflection angle = {:.1f}deg".format(y_turn, r / units.deg))
+                    "reflecting off surface at y = %.1fm, reflection angle = %.1fdeg", y_turn, r / units.deg)
                 output.append(r)
             else:
                 output.append(None)
@@ -1286,8 +1286,8 @@ class ray_tracing_2D(ray_tracing_base):
             res[~mask] = 2 * y_turn - get_y(gamma, C_0, C_1, self.medium.n_ice, self.__b, self.medium.z_0)
             zs[~mask] = 2 * z_turn - z[~mask]
 
-        self.__logger.debug('turning points for C_0 = {:.2f}, b= {:.2f}, gamma = {:.4f}, z = {:.1f}, y_turn = {:.0f}'.format(
-            C_0, self.__b, gamma_turn, z_turn, y_turn))
+        self.__logger.debug('turning points for C_0 = %.2f, b= %.2f, gamma = %.4f, z = %.1f, y_turn = %.0f',
+            C_0, self.__b, gamma_turn, z_turn, y_turn)
         return res, zs
 
     def get_path_reflections(self, x1, x2, C_0, n_points=1000, reflection=0, reflection_case=1):
@@ -1330,7 +1330,7 @@ class ray_tracing_2D(ray_tracing_base):
             # that will produce a downward going ray through x1
             y_turn = get_y_turn(C_0, x1, self.medium.n_ice, self.__b, self.medium.delta_n, self.medium.z_0)
             dy = y_turn - x1[0]
-            self.__logger.debug("relaction case 2: shifting x1 {} to {}".format(x1, x1[0] - 2 * dy))
+            self.__logger.debug("relaction case 2: shifting x1 %s to %s", x1, x1[0] - 2 * dy)
             x1[0] = x1[0] - 2 * dy
 
         if(reflection == 0):
@@ -1338,7 +1338,7 @@ class ray_tracing_2D(ray_tracing_base):
             return self.get_path(x1, x2, C_0, n_points)
         x22 = copy.copy(x2)
         for i in range(reflection + 1):
-            self.__logger.debug("calculation path for reflection = {}".format(i))
+            self.__logger.debug("calculation path for reflection = %d", i)
             C_1 = x1[0] - get_y_with_z_mirror(x1[1], C_0,self.medium.n_ice, self.__b, self.medium.delta_n, self.medium.z_0)[0]
             x2 = get_reflection_point(C_0, C_1,  self.medium.n_ice, self.reflection, self.__b, self.medium.z_0, self.medium.delta_n)
             if(x2[0] > x22[0]):
@@ -1346,7 +1346,7 @@ class ray_tracing_2D(ray_tracing_base):
             yyy, zzz = self.get_path(x1, x2, C_0, n_points)
             yy.extend(yyy)
             zz.extend(zzz)
-            self.__logger.debug("setting x1 from {} to {}".format(x1, x2))
+            self.__logger.debug("setting x1 from %s to %s", x1, x2)
             x1 = x2
 
         yy = np.array(yy)
@@ -1441,7 +1441,7 @@ class ray_tracing_2D(ray_tracing_base):
                 C_0_stop = self.get_C_0_from_angle(np.arcsin(1/self.medium.get_index_of_refraction([0, x1[0], x1[1]])), x1[1]).x[0]
                 logC0_stop = np.log(C_0_stop - 1/self.medium.n_ice)
                 delta_ys = [self.obj_delta_y(logC0, x1, x2, reflection, reflection_case) for logC0 in [logC0_start, logC0_stop]]
-                self.__logger.debug("Looking for ice-air solutions between log(C0) ({}, {}) with delta_y ({}, {})".format(logC0_start, logC0_stop, *delta_ys))
+                self.__logger.debug("Looking for ice-air solutions between log(C0) (%s, %s) with delta_y (%s, %s)", logC0_start, logC0_stop, *delta_ys)
                 if(np.sign(delta_ys[0]) == np.sign(delta_ys[1])):
                     self.__logger.warning(f"can't find a solution for ice/air propagation. The trajectory might be too vertical! This is currently not"\
                                           " supported because of numerical instabilities.")
@@ -1472,7 +1472,7 @@ class ray_tracing_2D(ray_tracing_base):
                 C_0_start, th_start = self.get_surf_skim_angle(x1)
                 logC_0_start = np.log(C_0_start - 1. / self.medium.n_ice)
                 self.__logger.debug(
-                    'starting optimization with x0 = {:.2f} -> C0 = {:.3f}'.format(logC_0_start, C_0_start))
+                    'starting optimization with x0 = %.2f -> C0 = %.3f', logC_0_start, C_0_start)
             else:
                 logC_0_start = -1
             obj_delta_y_sqr = obj_delta_y_square
@@ -2841,9 +2841,8 @@ class ray_tracing(ray_tracing_base):
                 lauVec1 = self._r1.get_launch_vector(iS)
                 lauAng1 = np.arccos(lauVec1[2] / np.sqrt(lauVec1[0] ** 2 + lauVec1[1] ** 2 + lauVec1[2] ** 2))
                 self.__logger.debug(
-                    "focusing: receive angle {:.2f} / launch angle {:.2f} / d_launch_angle {:.4f}".format(
-                        recAng / units.deg, lauAng / units.deg, (lauAng1-lauAng) / units.deg
-                    )
+                    "focusing: receive angle %.2f / launch angle %.2f / d_launch_angle %.4f",
+                    recAng / units.deg, lauAng / units.deg, (lauAng1-lauAng) / units.deg
                 )
                 focusing = np.sqrt(distance / np.sin(recAng) * np.abs((lauAng1 - lauAng) / (recPos1[2] - recPos[2])))
 
@@ -2861,7 +2860,7 @@ class ray_tracing(ray_tracing_base):
                 focusing = 1.0
                 self.__logger.warning("too few ray tracing solutions, setting focusing factor to 1")
 
-            self.__logger.debug(f'amplification due to focusing of solution {iS:d} = {focusing:.3f}')
+            self.__logger.debug('amplification due to focusing of solution %d = %.3f', iS, focusing)
             if(focusing > limit):
                 self.__logger.info(f"amplification due to focusing is {focusing:.1f}x -> limiting amplification factor to {limit:.1f}x")
                 focusing = limit
@@ -3008,7 +3007,8 @@ class ray_tracing(ray_tracing_base):
             spec[1] *= reflection_coefficient * np.exp(1j * phase_shift)
             spec[2] *= reflection_coefficient * np.exp(1j * phase_shift)
             self.__logger.debug(
-                f"ray is reflecting {i_reflections:d} times at the bottom -> reducing the signal by a factor of {reflection_coefficient:.2f}")
+                "ray is reflecting %d times at the bottom -> reducing the signal by a factor of %.2f",
+                i_reflections, reflection_coefficient)
 
         # apply the focusing effect
         if self._config['propagation']['focusing']:

--- a/NuRadioMC/simulation/simulation.py
+++ b/NuRadioMC/simulation/simulation.py
@@ -163,7 +163,7 @@ def calculate_sim_efield(
             time_logger.stop_time('distance cut')
 
         time_logger.start_time('ray tracing')
-        logger.debug(f"Calculating electric field for shower {shower.get_id()} and station {station_id}, channel {channel_id}")
+        logger.debug("Calculating electric field for shower %d and station %d, channel %d", shower.get_id(), station_id, channel_id)
         shower_direction = -1 * shower.get_axis() # We need the propagation direction here, so we multiply the shower axis with '-1'
         n_index = medium.get_index_of_refraction(x1)
         cherenkov_angle = np.arccos(1. / n_index)
@@ -175,12 +175,15 @@ def calculate_sim_efield(
             # TODO: initiatlize ray tracer with existing results if available
 
         propagator.find_solutions()
+        time_logger.stop_time('ray tracing')
         if not propagator.has_solution():
-            logger.debug(f"shower {shower.get_id()} and station {station_id}, channel {channel_id} from {x1} to {x2} does not have any ray tracing solution")
+            logger.debug("shower %d and station %d, channel %d from %s to %s does not have any ray tracing solution",
+                         shower.get_id(), station_id, channel_id, x1, x2)
             continue
 
         n = propagator.get_number_of_solutions()
-        logger.debug(f"found {n} solutions for shower {shower.get_id()} and station {station_id}, channel {channel_id} from {x1} to {x2}")
+        logger.debug("found %d solutions for shower %d and station %d, channel %d from %s to %s",
+                     n, shower.get_id(), station_id, channel_id, x1, x2)
 
         delta_Cs = np.zeros(n)
         viewing_angles = np.zeros(n)
@@ -193,10 +196,8 @@ def calculate_sim_efield(
         if min(np.abs(delta_Cs)) > config['speedup']['delta_C_cut']:
             logger.debug(f'delta_C too large, event unlikely to be observed, (min(Delta_C) = {min(np.abs(delta_Cs))/units.deg:.1f}deg), skipping event')
             continue
-        time_logger.stop_time('ray tracing')
 
         for iS in range(n): # loop through all ray tracing solution
-            time_logger.start_time('ray tracing (time)')
             # skip individual channels where the viewing angle difference is too large
             # discard event if delta_C (angle off cherenkov cone) is too large
             if np.abs(delta_Cs[iS]) > config['speedup']['delta_C_cut']:
@@ -204,9 +205,10 @@ def calculate_sim_efield(
                 continue
 
             # TODO: Fill with previous values if RT was already performed
+            time_logger.start_time('ray tracing (time)')
             wave_propagation_distance = propagator.get_path_length(iS)  # calculate path length
             wave_propagation_time = propagator.get_travel_time(iS)  # calculate travel time
-            time_logger.start_time('ray tracing (time)')
+            time_logger.stop_time('ray tracing (time)')
             if wave_propagation_distance is None or wave_propagation_time is None:
                 logger.warning('travel distance or travel time could not be calculated, skipping ray tracing solution. '
                                f'Shower ID: {shower.get_id()} Station ID: {station_id} Channel ID: {channel_id}')
@@ -282,8 +284,10 @@ def calculate_sim_efield(
             electric_field[efp.launch_vector] = propagator.get_launch_vector(iS)
 
             if min_efield_amplitude is not None:
+                time_logger.start_time('candidate check')
                 if np.max(np.abs(electric_field.get_trace())) > min_efield_amplitude:
                     sim_station.set_candidate(True)
+                time_logger.stop_time('candidate check')
 
             sim_station.add_electric_field(electric_field)
             logger.debug(
@@ -455,8 +459,10 @@ def calculate_sim_efield_for_emitter(
             electric_field[efp.launch_vector] = propagator.get_launch_vector(iS)
 
             if min_efield_amplitude is not None:
+                time_logger.start_time('candidate check')
                 if np.max(np.abs(electric_field.get_trace())) > min_efield_amplitude:
                     sim_station.set_candidate(True)
+                time_logger.stop_time('candidate check')
 
             sim_station.add_electric_field(electric_field)
 
@@ -1569,7 +1575,9 @@ class simulation:
                     if not evt.get_station().has_triggered():
                         continue
 
+                    time_logger.start_time('readout windows')
                     channelReadoutWindowCutter.run(evt, station, self._det)
+                    time_logger.stop_time('readout windows')
                     evt_group_triggered = True
                     output_buffer[station_id][evt.get_id()] = evt
                 # end event loop
@@ -1657,12 +1665,15 @@ class simulation:
                     if bool(self._config['noise']):
                         self.add_filtered_noise_to_channels(evt, station, non_trigger_channels)
 
+                    time_logger.start_time('signal reconstruction')
                     channelSignalReconstructor.run(evt, station, self._det)
+                    time_logger.stop_time('signal reconstruction')
                     self._set_event_station_parameters(evt)
 
                     i_triggered_events += 1 # count the number of triggered events
 
                     if self._outputfilenameNuRadioReco is not None:
+                        time_logger.start_time('event writer (nur)')
                         # downsample traces to detector sampling rate to save file size
                         sampling_rate_detector = self._det.get_sampling_frequency(
                             station_id, self._det.get_channel_ids(station_id)[0])
@@ -1692,6 +1703,7 @@ class simulation:
                             eventWriter.run(evt, self._det, mode=output_mode)
                         else:
                             eventWriter.run(evt, mode=output_mode)
+                        time_logger.stop_time('event writer (nur)')
 
                     remove_all_traces(evt)  # remove all traces to save memory
 
@@ -1716,6 +1728,7 @@ class simulation:
         The traces of the non-trigger channels already have the detector response applied to them.
         Hence we add "filtered" noise, i.e., noise which is based through the same filter seperatly.
         """
+        time_logger.start_time('noise (non-trigger channels)')
         station_id = station.get_id()
         for channel_id in channel_ids:
             channel = station.get_channel(channel_id)
@@ -1736,6 +1749,7 @@ class simulation:
 
             channel.set_frequency_spectrum(channel.get_frequency_spectrum() + noise, channel.get_sampling_rate())
 
+        time_logger.stop_time('noise (non-trigger channels)')
 
     def _add_empty_channel(self, station, channel_id):
         """ Adds a channel with an empty trace (all zeros) to the station with the correct length and trace_start_time """

--- a/NuRadioMC/simulation/time_logger.py
+++ b/NuRadioMC/simulation/time_logger.py
@@ -1,4 +1,4 @@
-import astropy.time
+import time
 
 
 def pretty_time_delta(seconds):
@@ -52,7 +52,7 @@ class timeLogger:
         The logger object used for logging.
     update_interval : int, optional
         The time interval (in seconds) at which the logger should be updated.
-        Default is 5 seconds.
+        Default is 20 seconds.
 
     Methods
     -------
@@ -68,7 +68,7 @@ class timeLogger:
         Display the progress information of a simulation run.
     """
 
-    def __init__(self, logger, update_interval=5):
+    def __init__(self, logger, update_interval=20):
         """
         Initialize the TimeLogger object.
 
@@ -78,14 +78,14 @@ class timeLogger:
             The logger object used for logging.
         update_interval : int, optional
             The time interval (in seconds) at which the logger should be updated.
-            Default is 5 seconds.
+            Default is 20 seconds.
         """
         self.__times = {}
         self.__total_start_time = None
         self.__start_times = {}
         self.__last_update = None
         self.__logger = logger
-        self.__update_interval = astropy.time.TimeDelta(update_interval, format='sec')
+        self.__update_interval = update_interval  # sec
 
     def reset_times(self, categories=None):
         """
@@ -113,8 +113,8 @@ class timeLogger:
         >>> logger.reset_times(['category1', 'category2'])  # Reset specific categories
         """
         self.__times = {}
-        self.__total_start_time = astropy.time.Time.now()
-        self.__last_update = astropy.time.Time.now()
+        self.__total_start_time = time.monotonic()
+        self.__last_update = time.monotonic()
 
         if categories is None:
             for key in self.__times:
@@ -134,7 +134,7 @@ class timeLogger:
 
         Notes
         -----
-        This method starts the timer for the specified category by recording the current time using `astropy.time.Time.now()`.
+        This method starts the timer for the specified category by recording the current time using `time.monotonic()`.
 
         If the category does not exist in the time log, it will be added and the timer will be reset to zero.
 
@@ -146,7 +146,7 @@ class timeLogger:
         if category not in self.__times:
             self.__times[category] = 0
             self.__logger.info(f"Time category {category} not found. Adding category and resetting time to zero.")
-        self.__start_times[category] = astropy.time.Time.now()
+        self.__start_times[category] = time.monotonic()
 
     def stop_time(self, category):
         """
@@ -170,7 +170,7 @@ class timeLogger:
         if category not in self.__start_times.keys() or self.__start_times[category] is None:
             raise RuntimeError('It looks like you stopped taking time for {} before starting it.'.format(category))
 
-        self.__times[category] += (astropy.time.Time.now() - self.__start_times[category]).sec
+        self.__times[category] += time.monotonic() - self.__start_times[category]
         self.__start_times[category] = None
 
     def show_time(self, n_event_groups, i_event_group):
@@ -187,22 +187,22 @@ class timeLogger:
         Raises:
             None
         """
-        if astropy.time.Time.now() - self.__last_update > self.__update_interval:
-            self.__last_update = astropy.time.Time.now()
-            elapsed_time = astropy.time.Time.now() - self.__total_start_time
+        if time.monotonic() - self.__last_update > self.__update_interval:
+            self.__last_update = time.monotonic()
+            elapsed_time = time.monotonic() - self.__total_start_time
             projected_time = elapsed_time * (n_event_groups - i_event_group - 1) / (i_event_group + 1)
             total_accounted_time = 0
             time_account_string = ''
             for category in self.__times:
                 total_accounted_time += self.__times[category]
-                time_account_string = time_account_string + '{} = {:.0f}%, '.format(category, self.__times[category] / elapsed_time.sec * 100)
+                time_account_string = time_account_string + '{} = {:.0f}%, '.format(category, self.__times[category] / elapsed_time * 100)
 
-            time_account_string = time_account_string + 'unaccounted: {:.0f}%'.format((elapsed_time.sec - total_accounted_time) / elapsed_time.sec * 100)
+            time_account_string = time_account_string + 'unaccounted: {:.0f}%'.format((elapsed_time - total_accounted_time) / elapsed_time * 100)
             self.__logger.status(
                 'Processing event group {}/{}. ETA: {}, time consumption: {}'.format(
                     i_event_group,
                     n_event_groups,
-                    pretty_time_delta(projected_time.sec),
+                    pretty_time_delta(projected_time),
                     time_account_string
                 )
             )


### PR DESCRIPTION
This PR improves the time logging used in `simulation.py` and does two things:

- Reduces the amount of unaccounted time in the time logging from >30% down to < 10% (these numbers are based on the used simulation setting and will change depending on the signal model or details of your detector simulation - e.g. trigger).
- Reduces the overall computing time by reducing overhead in timer_logger.py: This actually also accounts for the biggest drop in unaccounted time. By replacing astropy.time with time it saves quite some time (with my setting -41%)

Few other things:
- Better lazy string formatting for debug messages
- more time logger categories. 