### PR TITLE
Loop over sorted channel ids to calcualte noise vrms. Potentially cha…

### DIFF
--- a/NuRadioMC/simulation/simulation.py
+++ b/NuRadioMC/simulation/simulation.py
@@ -1307,7 +1307,7 @@ class simulation:
             self._integrated_channel_response_normalization[station_id] = {}
             self._max_amplification_per_channel[station_id] = {}
 
-            for channel_id in self._det.get_channel_ids(station_id):
+            for channel_id in np.sort(self._det.get_channel_ids(station_id)):
                 ff = np.linspace(0, 0.5 * self._config['sampling_rate'], 10000)
                 filt = np.ones_like(ff, dtype=complex)
                 for i, (name, instance, kwargs) in enumerate(evt.iter_modules(station_id)):
@@ -1716,7 +1716,7 @@ class simulation:
         self._output_writer_hdf5.calculate_Veff()
         if not self._output_writer_hdf5.write_output_file():
             logger.warning("No events were triggered. Writing empty HDF5 output file.")
-            
+
             self._output_writer_hdf5.write_empty_output_file(self._fin_attrs)
 
         return i_triggered_events


### PR DESCRIPTION
…nges what is stored in HDF5 under Vrms.

The commit message already says it. This might break the validation as a different channels Vrms is stored in the generic field `Vrms` in the HDF5 files. For the channel specific field I think we already sorted it in a PR a while ago. 

This is an actual bug because you do not really know for which channel `Vrms` steams. It depends on what `self._det.get_channel_ids(station_id))` returns with no guarantee that it is sorted.