### PR TITLE
Add caching to the raytracing class to avoid repeating the raytracer …

### DIFF
--- a/NuRadioMC/SignalProp/analyticraytracing.py
+++ b/NuRadioMC/SignalProp/analyticraytracing.py
@@ -2039,6 +2039,11 @@ class ray_tracing(ray_tracing_base):
         self._R = None
         self._x1 = None
         self._x2 = None
+        # caches for the attenuation and focusing factors. They are only valid for the current
+        # geometry and are invalidated whenever the solutions are reset. This avoids recalculating
+        # these (expensive) quantities if several showers/emitters are simulated at the same position
+        self._cache_attenuation = {}
+        self._cache_focusing = {}
 
 
     def reset_solutions(self):
@@ -2053,10 +2058,16 @@ class ray_tracing(ray_tracing_base):
         self._swap = None
         self._dPhi = None
         self._R = None
+        self._cache_attenuation = {}
+        self._cache_focusing = {}
 
     def set_start_and_end_point(self, x1, x2):
         """
         Set the start and end points of the raytracing
+
+        If the start and end points are identical to those of the previous ray tracing,
+        the existing solutions are kept and `find_solutions` will not recalculate them.
+        Call `reset_solutions` before this function to force a recalculation.
 
         Parameters
         ----------
@@ -2064,10 +2075,15 @@ class ray_tracing(ray_tracing_base):
             start point of the ray
         x2: 3dim np.array
             stop point of the ray
+
+        Returns
+        -------
+        geometry_changed: bool
+            False if the start and end points are unchanged with respect to the previous
+            ray tracing (in which case the existing solutions are kept), True otherwise.
         """
-
-
-        super().set_start_and_end_point(x1, x2)
+        if not super().set_start_and_end_point(x1, x2):
+            return False
 
         self._swap = False
         if(self._X2[2] < self._X1[2]):
@@ -2088,6 +2104,8 @@ class ray_tracing(ray_tracing_base):
         self._x1 = np.array([X1r[0], X1r[2]])
         self._x2 = np.array([X2r[0], X2r[2]])
         self.__logger.debug("2D points %s %s", self._x1, self._x2)
+
+        return True
 
     def set_solution(self, raytracing_results):
         """
@@ -2118,7 +2136,15 @@ class ray_tracing(ray_tracing_base):
     def find_solutions(self):
         """
         find all solutions between x1 and x2
+
+        If solutions for the current start and end points already exist (i.e., the geometry
+        did not change since the last ray tracing or the solutions were set with `set_solution`),
+        they are kept and not recalculated. Call `reset_solutions` first to force a recalculation.
         """
+        if self._results is not None:
+            self.__logger.debug("solutions for the current geometry already exist, skipping ray tracing")
+            return
+
         self._results = self._r2d.find_solutions(self._x1, self._x2)
         for i in range(self._n_reflections):
             for j in range(2):
@@ -2771,9 +2797,18 @@ class ray_tracing(ray_tracing_base):
             raise IndexError
 
         result = self._results[iS]
-        return self._r2d.get_attenuation_along_path(self._x1, self._x2, result['C0'], frequency, max_detector_freq,
-                                                     reflection=result['reflection'],
-                                                     reflection_case=result['reflection_case'])
+        # the C0 parameter (together with the reflection specifiers) uniquely identifies the ray path
+        # for the current geometry, hence the attenuation only needs to be calculated once per path
+        # and frequency grid
+        cache_key = (result['C0'], result['reflection'], result['reflection_case'],
+                     np.asarray(frequency).tobytes(), max_detector_freq)
+        if cache_key not in self._cache_attenuation:
+            self._cache_attenuation[cache_key] = self._r2d.get_attenuation_along_path(
+                self._x1, self._x2, result['C0'], frequency, max_detector_freq,
+                reflection=result['reflection'],
+                reflection_case=result['reflection_case'])
+
+        return np.copy(self._cache_attenuation[cache_key])
 
     def get_focusing(self, iS, dz=-1. * units.cm, limit=2., analytic=False):
         """
@@ -2803,6 +2838,13 @@ class ray_tracing(ray_tracing_base):
         focusing: float
             gain of the signal at the receiver due to the focusing effect
         """
+        # the C0 parameter uniquely identifies the ray path for the current geometry. The focusing
+        # factor is requested several times per solution (e.g. by `get_raytracing_output` and
+        # `apply_propagation_effects`), hence, caching it avoids expensive recalculations
+        # (the numerical calculation requires an additional ray tracing)
+        cache_key = (iS, self._results[iS]['C0'], dz, limit, analytic)
+        if cache_key in self._cache_focusing:
+            return self._cache_focusing[cache_key]
 
         recVec = self.get_receive_vector(iS)
         recVec = -1.0 * recVec
@@ -2884,6 +2926,7 @@ class ray_tracing(ray_tracing_base):
             n_at_surface = self._medium.get_index_of_refraction([0, 0, -0.01*units.m])
             f *= np.sqrt(n_at_surface/n1 * np.abs(np.cos(np.arcsin(np.sin(lauAng) / n_at_surface)) / np.cos(lauAng)))
 
+        self._cache_focusing[cache_key] = f
         return f
 
     def get_ray_path(self, iS):

--- a/NuRadioMC/SignalProp/analyticraytracing.py
+++ b/NuRadioMC/SignalProp/analyticraytracing.py
@@ -2800,7 +2800,7 @@ class ray_tracing(ray_tracing_base):
         # the C0 parameter (together with the reflection specifiers) uniquely identifies the ray path
         # for the current geometry, hence the attenuation only needs to be calculated once per path
         # and frequency grid
-        cache_key = (result['C0'], result['reflection'], result['reflection_case'],
+        cache_key = (self._x1.tobytes(), self._x2.tobytes(), result['C0'], result['reflection'], result['reflection_case'],
                      np.asarray(frequency).tobytes(), max_detector_freq)
         if cache_key not in self._cache_attenuation:
             self._cache_attenuation[cache_key] = self._r2d.get_attenuation_along_path(
@@ -2842,7 +2842,7 @@ class ray_tracing(ray_tracing_base):
         # factor is requested several times per solution (e.g. by `get_raytracing_output` and
         # `apply_propagation_effects`), hence, caching it avoids expensive recalculations
         # (the numerical calculation requires an additional ray tracing)
-        cache_key = (iS, self._results[iS]['C0'], dz, limit, analytic)
+        cache_key = (self._x1.tobytes(), self._x2.tobytes(), iS, self._results[iS]['C0'], dz, limit, analytic)
         if cache_key in self._cache_focusing:
             return self._cache_focusing[cache_key]
 

--- a/NuRadioMC/SignalProp/propagation_base_class.py
+++ b/NuRadioMC/SignalProp/propagation_base_class.py
@@ -81,6 +81,8 @@ class ray_tracing_base:
 
         self._X1 = None
         self._X2 = None
+        self._X1_input = None  # used for caching
+        self._X2_input = None
         self._results = None
 
     def _set_arguments(self, n_frequencies_integration, n_reflections, attenuation_model):
@@ -135,13 +137,18 @@ class ray_tracing_base:
     def reset_solutions(self):
         self._X1 = None
         self._X2 = None
+        self._X1_input = None
+        self._X2_input = None
         self._results = None
 
     def set_start_and_end_point(self, x1, x2):
         """
-        Set the start and end points between which raytracing solutions shall be found
-        It is recommended to also reset the solutions from any previous raytracing to avoid
-        confusing them with the current solution
+        Set the start and end points between which raytracing solutions shall be found.
+
+        If the start and end points are identical to those of the previous ray tracing,
+        the existing solutions are kept and `find_solutions` will not recalculate them
+        (relevant e.g. if several showers are simulated at the same position).
+        Call `reset_solutions` before this function to force a recalculation.
 
         Parameters
         ----------
@@ -149,16 +156,35 @@ class ray_tracing_base:
             start point of the ray
         x2: np.array of shape (3,), default unit
             stop point of the ray
+
+        Returns
+        -------
+        geometry_changed: bool
+            False if the start and end points are unchanged with respect to the previous
+            ray tracing (in which case the existing solutions are kept), True otherwise.
         """
+        x1 = np.array(x1, dtype=float)
+        x2 = np.array(x2, dtype=float)
+        if (self._results is not None and self._X1_input is not None
+                and np.array_equal(x1, self._X1_input) and np.array_equal(x2, self._X2_input)):
+            self.__logger.debug("start and end points are unchanged, keeping existing ray tracing solutions")
+            return False
+
         self.reset_solutions()
-        self._X1 = np.array(x1, dtype =float)
-        self._X2 = np.array(x2, dtype = float)
+        # keep a copy of the unmodified input points to detect geometry changes
+        # (subclasses may modify self._X1/self._X2, e.g., swap them)
+        self._X1_input = x1
+        self._X2_input = x2
+        self._X1 = np.copy(x1)
+        self._X2 = np.copy(x2)
         if (self._n_reflections):
             if (self._X1[2] < self._medium.reflection or self._X2[2] < self._medium.reflection):
                 self.__logger.error("start or stop point is below the reflective bottom layer at {:.1f}m".format(
                     self._medium.reflection / units.m))
                 raise AttributeError("start or stop point is below the reflective bottom layer at {:.1f}m".format(
                     self._medium.reflection / units.m))
+
+        return True
 
     def use_optional_function(self, function_name, *args, **kwargs):
         """

--- a/NuRadioMC/SignalProp/radioproparaytracing.py
+++ b/NuRadioMC/SignalProp/radioproparaytracing.py
@@ -133,18 +133,31 @@ class radiopropa_ray_tracing(ray_tracing_base):
         """
         Set the start and end points of the raytracing
 
+        If the start and end points are identical to those of the previous ray tracing,
+        the existing solutions are kept and `find_solutions` will not recalculate them.
+        Call `reset_solutions` before this function to force a recalculation.
+
         Parameters
         ----------
         x1: 3dim np.array
             start point of the ray
         x2: 3dim np.array
             stop point of the ray
+
+        Returns
+        -------
+        geometry_changed: bool
+            False if the start and end points are unchanged with respect to the previous
+            ray tracing (in which case the existing solutions are kept), True otherwise.
         """
         self._source = x1
         self._antenna = x2
 
-        super().set_start_and_end_point(x1, x2)
+        if not super().set_start_and_end_point(x1, x2):
+            return False
+
         self.set_iterative_step_sizes(step_zeniths=self._step_zeniths) #if auto is on this set the automated step size, otherwise nothing happens
+        return True
 
     def set_shower_axis(self, shower_axis):
         """
@@ -155,7 +168,14 @@ class radiopropa_ray_tracing(ray_tracing_base):
         shower_axis: np.array of shape (3,), default unit
             the direction of the shower in cartesian coordinates
         """
-        self._shower_axis = shower_axis / np.linalg.norm(shower_axis)
+        shower_axis = shower_axis / np.linalg.norm(shower_axis)
+        if self._shower_axis is not None and not np.array_equal(shower_axis, self._shower_axis):
+            # the solutions can depend on the shower axis (rays are preselected with a viewing angle
+            # cut around the cherenkov angle), so existing solutions have to be recalculated
+            self._results = None
+            self._rays = None
+
+        self._shower_axis = shower_axis
 
     def set_iterative_sphere_sizes(self, sphere_sizes=None):
         """
@@ -650,7 +670,14 @@ class radiopropa_ray_tracing(ray_tracing_base):
     def find_solutions(self):
         """
         find all solutions between X1 and X2
+
+        If solutions for the current start and end points (and shower axis) already exist,
+        they are kept and not recalculated. Call `reset_solutions` first to force a recalculation.
         """
+        if self._results is not None:
+            self.__logger.debug("solutions for the current geometry already exist, skipping ray tracing")
+            return
+
         results = []
         rays_results = []
 

--- a/NuRadioMC/simulation/simulation.py
+++ b/NuRadioMC/simulation/simulation.py
@@ -154,8 +154,12 @@ def calculate_sim_efield(
         x1 = shower.get_parameter(shp.vertex)
         if distance_cut is not None:
             time_logger.start_time('distance cut')
+            # Aggregate energy of showers which are close to the shower in question
             mask_shower_sum = np.abs(vertex_distances - vertex_distances[iSh]) < config['speedup']['distance_cut_sum_length']
             shower_energy_sum = np.sum(shower_energies[mask_shower_sum])
+
+            # Check with the aggregated energy whether the shower could be detected.
+            # (This does not skip showers which are to close to a other shower!)
             if np.linalg.norm(x1 - x2) > distance_cut(shower_energy_sum):
                 time_logger.stop_time('distance cut')
                 continue
@@ -168,14 +172,16 @@ def calculate_sim_efield(
         n_index = medium.get_index_of_refraction(x1)
         cherenkov_angle = np.arccos(1. / n_index)
 
+        if config['speedup']['redo_raytracing']:
+            # force a recalculation even if solutions for the same geometry (e.g., from a previous
+            # shower at the same position) are still stored in the propagator
+            propagator.reset_solutions()
+
         propagator.set_start_and_end_point(x1, x2)
         propagator.use_optional_function('set_shower_axis', shower_direction)
-        if config['speedup']['redo_raytracing']:  # check if raytracing was already performed
-            pass
-            # TODO: initiatlize ray tracer with existing results if available
-
         propagator.find_solutions()
         time_logger.stop_time('ray tracing')
+
         if not propagator.has_solution():
             logger.debug("shower %d and station %d, channel %d from %s to %s does not have any ray tracing solution",
                          shower.get_id(), station_id, channel_id, x1, x2)
@@ -354,12 +360,15 @@ def calculate_sim_efield_for_emitter(
         x1 = emitter.get_parameter(ep.position)
         n_index = medium.get_index_of_refraction(x1)
 
+        if config['speedup']['redo_raytracing']:
+            # force a recalculation even if solutions for the same geometry (e.g., from a previous
+            # emitter at the same position) are still stored in the propagator
+            propagator.reset_solutions()
+
         propagator.set_start_and_end_point(x1, x2)
-        if config['speedup']['redo_raytracing']:  # check if raytracing was already performed
-            pass
-            # TODO: initiatlize ray tracer with existing results if available
         propagator.find_solutions()
         time_logger.stop_time('ray tracing')
+
         if not propagator.has_solution():
             logger.debug(f"emitter {emitter.get_id()} and station {station_id}, "
                         f"channel {channel_id} from {x1} to {x2} does not have any ray tracing solution")


### PR DESCRIPTION
…calculation for a set of consecutive identical source/receiver pairs

This PR implements caching into the raytracer class. This caching is only "active" if consecutive calls (`propagator.set_start_and_end_point(x1, x2)`, `propagator.find_solutions()`) have the exact same `x1` and `x2`.  This can happen for example for `nu_e` cc interactions. We are not only caching the result of `find_solutions` but also the attenuation and focusing calculation. In particular the latter is relevant as currently we are calculating it twice per shower (!) once in `apply_propagation_effects` and once in `get_raytracing_output` (so for a `nu_e`-cc we are calculating the same thing 4 times). 

Note: The raytracing solution of a `nu_e`-cc event is only equal for both showers since we are **not** currently taking the shower Xmax in raytracing into account. If that changes this feature needs to be revisited.