### PR TITLE
Add deprecated decorator for deprecated functions/classes

### DIFF
--- a/NuRadioReco/utilities/logging.py
+++ b/NuRadioReco/utilities/logging.py
@@ -1,4 +1,6 @@
 import logging
+import warnings
+from functools import wraps
 
 LOGGING_STATUS = 25
 INFO = logging.INFO
@@ -182,3 +184,33 @@ def set_general_log_level(level):
 
     nrmc_logger = logging.getLogger("NuRadioMC")
     nrmc_logger.setLevel(level)
+
+try:
+    from warnings import deprecated # only available in Python >= 3.13
+except ImportError:
+    def deprecated(msg, *, category=DeprecationWarning, stacklevel=1):
+        """Decorator for deprecated functions/classes
+
+        Parameters
+        ----------
+        msg : str
+            Message that is displayed when the deprecated class / function is called
+
+        Other Parameters
+        ----------------
+        category : Warning, optional
+            Type of warning to emit (default: DeprecationWarning)
+        stacklevel : int, optional
+            stacklevel passed on to `warnings.warn`. Default is 1.
+        """
+
+        def func_decorator(func):
+
+            @wraps(func)
+            def deprecated_fn(*args, **kwargs):
+                warnings.warn(message=msg, category=category, stacklevel=stacklevel)
+                return func(*args, **kwargs)
+
+            return deprecated_fn
+
+        return func_decorator


### PR DESCRIPTION
Because I was looking at deprecation warnings, I noticed that Python 3.13 introduced a very nice decorator for marking functions/classes as deprecated (https://docs.python.org/3.13/library/warnings.html#warnings.deprecated). I decided to copy the API and implement the same thing, so that if we ever want to deprecate a function in the future it's as simple as adding the decorator:
```
@deprecated('This function is deprecated, please use nondeprecated_function instead')
def deprecated_function(...):
    ...
```

I don't know how useful this is yet but thought it was neat and wanted to practise my decorators, and having done that thought I might as well share it.