### PR TITLE
RNO_G Detector.update() returns whether an update actually happened

### DIFF
--- a/NuRadioReco/detector/RNO_G/rnog_detector.py
+++ b/NuRadioReco/detector/RNO_G/rnog_detector.py
@@ -477,6 +477,14 @@ class Detector():
         ----------
         time: `datetime.datetime` or ``astropy.time.Time``
             Unix time of measurement.
+
+        Returns
+        -------
+
+        updated: bool
+            True if the detector description was (re-)queried from the database because the
+            detector time moved into a new period. False if the buffered description was still
+            valid and no update was necessary.
         """
         if isinstance(time, astropy.time.Time):
             time = _convert_astro_time_to_datetime(time)
@@ -489,7 +497,7 @@ class Detector():
             self.__db.set_detector_time(time)
 
         update_buffer_for_station = self._check_update_buffer()
-        any_update = np.any([v for v in update_buffer_for_station.values()])
+        any_update = bool(np.any([v for v in update_buffer_for_station.values()]))
 
         if self._det_imported_from_file and any_update:
             self.logger.warning(f"Update detector to {time}")
@@ -512,14 +520,15 @@ class Detector():
         # Return when buffer is not empty. This has to come first ...
         for station_id in self.__buffered_stations:
             if len(self.__buffered_stations[station_id]):
-                return
+                return any_update
 
         # ... and than second
         if len(self.__buffered_stations):
-            return
+            return any_update
 
         # When you reach this point something went wrong ...
         self.logger.warning(f"Empty detector for {time}!")
+        return any_update
 
 
     @_check_detector_time


### PR DESCRIPTION
## Summary
- `Detector.update()` in `NuRadioReco/detector/RNO_G/rnog_detector.py` previously always returned `None`.
- It now returns `True` if the detector description was (re-)queried from the database because the detector time moved into a new period, and `False` if the buffered description was still valid and no update was necessary.

## Test plan
- [x] Verified no existing call sites in the repo check the return value of `update()`, so this is backwards compatible.
- [x] Ran `NuRadioReco/detector/test/test_rnog_detector.py` (both `always_query_entire_description=True/False`) against `RNOG_public` — passes.
- [x] Smoke-tested return values directly against `RNOG_public`: first `update()` → `True`, same-period `update()` → `False`, cross-period `update()` → `True`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)