### PR TITLE
ParameterStorage.get_parameter now returns a copy of mutable values

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -280,6 +280,11 @@ jobs:
       run: |
         python NuRadioReco/test/check_modules.py -r
 
+    - name: "Test ParameterStorage get/set copy semantics"
+      if: always()
+      run: |
+        python NuRadioReco/test/framework/test_parameter_storage.py
+
     - name: "Test calibration pulser example"
       if: always()
       run: |

--- a/NuRadioReco/framework/parameter_storage.py
+++ b/NuRadioReco/framework/parameter_storage.py
@@ -13,6 +13,15 @@ import itertools
 import logging
 logger = logging.getLogger('NuRadioReco.framework.parameter_storage')
 
+# Module-level alias so `get_parameter` can use a `copy` keyword argument
+# without shadowing the `copy` module inside its own body.
+_deepcopy = copy.deepcopy
+
+# Types that can never be mutated in place, so returning them without copying
+# is always safe. Everything else (list, dict, set, numpy.ndarray, custom
+# objects, ...) is deep-copied by `get_parameter` unless `copy=False`.
+_IMMUTABLE_SCALAR_TYPES = (int, float, complex, bool, str, bytes, type(None))
+
 
 class ParameterStorage:
     """
@@ -65,10 +74,32 @@ class ParameterStorage:
             logger.error(f"Parameter {key} needs to be of type {self._parameter_types}")
             raise ValueError(f"Parameter {key} needs to be of type {self._parameter_types}")
 
-    def get_parameter(self, key):
-        """ Get a parameter """
+    def get_parameter(self, key, copy=True):
+        """
+        Get a parameter
+
+        Parameters
+        ----------
+        key : parameter key
+            The parameter to retrieve.
+        copy : bool (default: True)
+            If `True` (default), mutable values (e.g. `list`, `dict`, `numpy.ndarray`) are
+            deep-copied before being returned, so that modifying the returned value does not
+            also modify the parameter stored in this object. Values of immutable types (e.g.
+            `int`, `float`, `str`, `None`) are never copied, since they cannot be mutated in
+            place regardless of this option.
+
+            Set to `False` to retrieve the stored object itself without copying, e.g. for
+            read-only access to large objects in performance-critical code. Note that in this
+            case, any in-place modification of the returned object will also modify the
+            parameter stored in this object.
+        """
         self._check_key(key)
-        return self._parameters[key]
+        value = self._parameters[key]
+        if copy and not isinstance(value, _IMMUTABLE_SCALAR_TYPES):
+            value = _deepcopy(value)
+
+        return value
 
     def has_parameter(self, key):
         """ Returns `True` if the parameter `key` is present, `False` otherwise """

--- a/NuRadioReco/modules/custom/deltaT/calculateAmplitudePerRaySolution.py
+++ b/NuRadioReco/modules/custom/deltaT/calculateAmplitudePerRaySolution.py
@@ -74,8 +74,16 @@ class calculateAmplitudePerRaySolution:
                 if not efield.has_parameter(efp.max_amp_antenna):
                     efield[efp.max_amp_antenna] = {}
                     efield[efp.max_amp_antenna_envelope] = {}
-                efield[efp.max_amp_antenna][channel_id] = maximum
-                efield[efp.max_amp_antenna_envelope][channel_id] = maximum_envelope
+
+                # `get_parameter` returns a copy of the stored dict, so it needs to be
+                # written back with `set_parameter` after being updated in place.
+                max_amp_antenna = efield[efp.max_amp_antenna]
+                max_amp_antenna[channel_id] = maximum
+                efield[efp.max_amp_antenna] = max_amp_antenna
+
+                max_amp_antenna_envelope = efield[efp.max_amp_antenna_envelope]
+                max_amp_antenna_envelope[channel_id] = maximum_envelope
+                efield[efp.max_amp_antenna_envelope] = max_amp_antenna_envelope
 
         self.__t += time.time() - t
 

--- a/NuRadioReco/test/framework/test_parameter_storage.py
+++ b/NuRadioReco/test/framework/test_parameter_storage.py
@@ -1,0 +1,115 @@
+"""
+Tests that `ParameterStorage.get_parameter` (and the `[]` operator, which uses it
+under the hood) returns a copy of mutable parameter values, so that modifying the
+returned value does not silently corrupt the object's internal state.
+"""
+import numpy as np
+
+from NuRadioReco.framework.parameters import stationParameters as stnp
+from NuRadioReco.framework.station import Station
+from NuRadioReco.framework.electric_field import ElectricField
+from NuRadioReco.framework.parameters import electricFieldParameters as efp
+
+
+def _make_storage():
+    # `ParameterStorage` is not meant to be instantiated directly; use a real
+    # subclass (`Station`) instead, which is set up with valid parameter types.
+    return Station(0)
+
+
+def test_list_parameter_is_copied():
+    station = _make_storage()
+    station.set_parameter(stnp.dirty_fft_channels, [1, 2, 3])
+
+    retrieved = station.get_parameter(stnp.dirty_fft_channels)
+    retrieved.append(4)
+
+    assert station.get_parameter(stnp.dirty_fft_channels) == [1, 2, 3]
+    assert retrieved == [1, 2, 3, 4]
+
+
+def test_dict_parameter_is_copied():
+    station = _make_storage()
+    station.set_parameter(stnp.cr_xcorrelations, {"a": 1})
+
+    retrieved = station.get_parameter(stnp.cr_xcorrelations)
+    retrieved["b"] = 2
+
+    assert station.get_parameter(stnp.cr_xcorrelations) == {"a": 1}
+    assert retrieved == {"a": 1, "b": 2}
+
+
+def test_nested_mutable_parameter_is_deep_copied():
+    station = _make_storage()
+    station.set_parameter(stnp.viewing_angles, {0: {0: 1.23}})
+
+    retrieved = station.get_parameter(stnp.viewing_angles)
+    retrieved[0][0] = 99.0
+
+    # the nested dict must not be shared, otherwise this in-place edit would
+    # leak into the stored parameter
+    assert station.get_parameter(stnp.viewing_angles) == {0: {0: 1.23}}
+
+
+def test_numpy_array_parameter_is_copied():
+    station = _make_storage()
+    array = np.array([1.0, 2.0, 3.0])
+    station.set_parameter(stnp.nu_vertex, array)
+
+    retrieved = station.get_parameter(stnp.nu_vertex)
+    retrieved[0] = 99.0
+
+    np.testing.assert_array_equal(station.get_parameter(stnp.nu_vertex), [1.0, 2.0, 3.0])
+    assert retrieved[0] == 99.0
+
+
+def test_getitem_operator_also_copies():
+    station = _make_storage()
+    station.set_parameter(stnp.dirty_fft_channels, [1, 2, 3])
+
+    station[stnp.dirty_fft_channels].append(4)
+
+    assert station[stnp.dirty_fft_channels] == [1, 2, 3]
+
+
+def test_scalar_parameter_returned_directly_without_copy_overhead():
+    station = _make_storage()
+    station.set_parameter(stnp.nu_energy, 1e18)
+
+    # scalars are immutable, so identity is preserved (and no needless copy is made)
+    assert station.get_parameter(stnp.nu_energy) is station.get_parameter(stnp.nu_energy)
+
+
+def test_copy_false_returns_the_stored_object_itself():
+    station = _make_storage()
+    stored = [1, 2, 3]
+    station.set_parameter(stnp.dirty_fft_channels, stored)
+
+    retrieved = station.get_parameter(stnp.dirty_fft_channels, copy=False)
+
+    assert retrieved is stored
+
+
+def test_set_parameter_after_get_modify_round_trip():
+    # regression test for the pattern used throughout the codebase to safely
+    # mutate a dict/list-valued parameter: get it, modify the copy, then set it back
+    efield = ElectricField([0])
+    efield.set_parameter(efp.max_amp_antenna, {})
+
+    max_amp_antenna = efield.get_parameter(efp.max_amp_antenna)
+    max_amp_antenna[0] = 1.5
+    efield.set_parameter(efp.max_amp_antenna, max_amp_antenna)
+
+    assert efield.get_parameter(efp.max_amp_antenna) == {0: 1.5}
+
+
+if __name__ == "__main__":
+    test_list_parameter_is_copied()
+    test_dict_parameter_is_copied()
+    test_nested_mutable_parameter_is_deep_copied()
+    test_numpy_array_parameter_is_copied()
+    test_getitem_operator_also_copies()
+    test_scalar_parameter_returned_directly_without_copy_overhead()
+    test_copy_false_returns_the_stored_object_itself()
+    test_set_parameter_after_get_modify_round_trip()
+    print("test_parameter_storage.py: all tests passed")


### PR DESCRIPTION
## Summary

`ParameterStorage.get_parameter` (and the `[]` operator, which is built on it) returned mutable parameter values (`list`, `dict`, `numpy.ndarray`, ...) by reference. Any in-place mutation of the returned value — `station[stnp.dirty_fft_channels].append(...)`, `efield[efp.max_amp_antenna][ch_id] = x`, etc. — silently mutated the stored parameter too, with no `set_parameter` call anywhere in sight. `get_parameters()` (plural) already guards against this by unconditionally `copy.deepcopy`-ing; the singular getter never got the same treatment.

- `get_parameter(self, key, copy=True)` now deep-copies mutable values before returning them. Values of immutable types (`int`, `float`, `complex`, `bool`, `str`, `bytes`, `None`) are returned as-is, since they can't be mutated in place and copying them would just be overhead for no safety benefit.
- `copy=False` is an explicit opt-out for read-only, performance-sensitive call sites that want the stored object itself.
- `set_parameter` is intentionally untouched — it still stores whatever reference it's given, same as `dict.__setitem__`. Symmetric copy-on-set is a separate discussion.

### Is this a behavior change or a bug fix?

The old reference-sharing behavior could be read as intentional, since one module (`calculateAmplitudePerRaySolution.py`) actively depended on `get_parameter`/`[]` handing back the *live* stored object so it could mutate it in place — see below. But that's one caller leaning on an implicit, undocumented aliasing contract, not the norm. Every other call site in the codebase treats the return value as a read-only snapshot, which is what most users of a `get_x()`-style accessor would expect by default, and is exactly the contract `get_parameters()` (plural) already documents.

So this PR treats the old aliasing as a latent bug one module happened to depend on, not a feature being taken away — and the old zero-copy behavior remains available, just opt-in via `get_parameter(key, copy=False)`, for anyone who genuinely wants it (e.g. a hot loop mutating a stored container in place on purpose).

### Fallout found while auditing the codebase

Grepped for code that fetches a mutable parameter and mutates it in place without an explicit `set_parameter` afterwards — that pattern would silently break once `get_parameter` stops returning a live reference.

Found one real instance: `NuRadioReco/modules/custom/deltaT/calculateAmplitudePerRaySolution.py` initialized `efp.max_amp_antenna`/`efp.max_amp_antenna_envelope` to `{}` once, then did `efield[efp.max_amp_antenna][channel_id] = maximum` on every subsequent channel, relying on the returned dict being the actual stored object. Fixed to fetch, mutate, and write back explicitly.

Everywhere else this pattern appears (`stationRFIFilter.py`, `planeWaveDirectionFitter_LOFAR.py`, `channelTemplateCorrelation.py`, ...) the code already calls `set_parameter` again after mutating the fetched value, so those were already correct and are unaffected by this change.

## Test plan

- [x] Added `NuRadioReco/test/framework/test_parameter_storage.py`: list/dict/numpy-array parameters are copied on get, nested mutable structures are deep- not shallow-copied, the `[]` operator also copies, scalar parameters are returned by identity (no copy overhead), `copy=False` returns the exact stored object, and the get→mutate→set round trip used elsewhere in the codebase still works. Wired into CI (`other-tests` job).
- [x] Ran `NuRadioReco/test/likelihood_reconstruction/test_efield_reconstruction.py` (exercises `get_parameter`/`[]` on `ElectricField` extensively, checked against fixed reference values) — passes unchanged.
- [x] Ran `NuRadioReco/test/check_modules.py -r` — no new breakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)