### PR TITLE
Hotfix antennapattern; extend test suit

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -230,6 +230,11 @@ jobs:
       run: |
         python NuRadioReco/detector/test/test_response.py
 
+    - name: "detector.antennapattern"
+      if: always()
+      run: |
+        python NuRadioReco/detector/test/test_antennapattern.py
+
     - name: "Test unfolding with voltageToEfieldConverter"
       if: always()
       run: |

--- a/NuRadioReco/detector/antennapattern.py
+++ b/NuRadioReco/detector/antennapattern.py
@@ -86,6 +86,36 @@ def interpolate_linear_vectorized(x, x0, x1, y0, y1, interpolation_method='compl
     return result
 
 
+def get_bracketing_indices(x, nodes):
+    """
+    Find the indices of the two grid nodes bracketing the requested position(s)
+
+    The nodes are only required to be sorted, not equally spaced. Positions outside
+    the node range are clamped to the outermost interval (i.e. they are extrapolated);
+    callers are expected to handle out-of-range values themselves if that is not wanted.
+
+    Parameters
+    ----------
+    x: float or array of floats
+        the requested position(s)
+    nodes: array of floats
+        the (sorted) grid nodes
+
+    Returns
+    -------
+    i_lower, i_upper: array of ints
+        indices of the nodes below and above ``x``. They are identical if the grid
+        has only a single node.
+    """
+    n = len(nodes)
+    if n == 1:
+        zero = np.zeros_like(x, dtype=int)
+        return zero, zero
+
+    i_upper = np.array(np.clip(np.searchsorted(nodes, x, side='left'), 1, n - 1), dtype=int)
+    return i_upper - 1, i_upper
+
+
 def get_group_delay(vector_effective_length, df):
     """
     helper function to calculate the group delay from the vector effecitve length
@@ -1445,37 +1475,18 @@ class AntennaPattern(AntennaPatternBase):
             logger.debug("{0},{1},{2}".format(freq, self.frequency_lower_bound, self.frequency_upper_bound))
             return np.zeros(shape=(2,1), dtype=complex)
 
-        if self.theta_upper_bound == self.theta_lower_bound:
-            iTheta_lower = 0
-            iTheta_upper = 0
-        else:
-            iTheta_lower = np.array(np.floor(
-                (theta - self.theta_lower_bound) / (self.theta_upper_bound - self.theta_lower_bound) * (
-                    self.n_theta - 1)), dtype=int)
-            iTheta_upper = np.array(np.ceil(
-                (theta - self.theta_lower_bound) / (self.theta_upper_bound - self.theta_lower_bound) * (
-                    self.n_theta - 1)), dtype=int)
+        # the angular and frequency grids are not necessarily equally spaced (e.g. the
+        # theta grid of RNOG_vpol_4inch_center_n1.73), hence look up the bracketing
+        # nodes instead of calculating their indices from the grid boundaries
+        iTheta_lower, iTheta_upper = get_bracketing_indices(theta, self.theta_angles)
         theta_lower = self.theta_angles[iTheta_lower]
         theta_upper = self.theta_angles[iTheta_upper]
-        if self.phi_upper_bound == self.phi_lower_bound:
-            iPhi_lower = 0
-            iPhi_upper = 0
-        else:
-            iPhi_lower = np.array(np.floor(
-                (phi - self.phi_lower_bound) / (self.phi_upper_bound - self.phi_lower_bound) * (self.n_phi - 1)),
-                dtype=int)
-            iPhi_upper = np.array(np.ceil(
-                (phi - self.phi_lower_bound) / (self.phi_upper_bound - self.phi_lower_bound) * (self.n_phi - 1)),
-                dtype=int)
+
+        iPhi_lower, iPhi_upper = get_bracketing_indices(phi, self.phi_angles)
         phi_lower = self.phi_angles[iPhi_lower]
         phi_upper = self.phi_angles[iPhi_upper]
 
-        iFrequency_lower = np.array(np.floor(
-            (freq - self.frequency_lower_bound) / (self.frequency_upper_bound - self.frequency_lower_bound) * (
-                self.n_freqs - 1)), dtype=int)
-        iFrequency_upper = np.array(np.ceil(
-            (freq - self.frequency_lower_bound) / (self.frequency_upper_bound - self.frequency_lower_bound) * (
-                self.n_freqs - 1)), dtype=int)
+        iFrequency_lower, iFrequency_upper = get_bracketing_indices(freq, self.frequencies)
         # handling frequency out of bound cases properly
         out_of_bound_freqs_low = freq < self.frequency_lower_bound
         out_of_bound_freqs_high = freq > self.frequency_upper_bound

--- a/NuRadioReco/detector/antennapattern.py
+++ b/NuRadioReco/detector/antennapattern.py
@@ -86,7 +86,18 @@ def interpolate_linear_vectorized(x, x0, x1, y0, y1, interpolation_method='compl
     return result
 
 
-def get_bracketing_indices(x, nodes):
+def is_equidistant(nodes, rtol=1e-4):
+    """
+    Check whether the grid nodes are equally spaced (within ``rtol`` of the spacing)
+    """
+    if len(nodes) < 3:
+        return True
+
+    spacing = np.diff(nodes)
+    return bool(np.ptp(spacing) < rtol * np.abs(np.mean(spacing)))
+
+
+def get_bracketing_indices(x, nodes, equidistant=False):
     """
     Find the indices of the two grid nodes bracketing the requested position(s)
 
@@ -100,6 +111,10 @@ def get_bracketing_indices(x, nodes):
         the requested position(s)
     nodes: array of floats
         the (sorted) grid nodes
+    equidistant: bool (default: False)
+        if True the indices are calculated from the grid boundaries instead of looked up.
+        This is much faster for large ``x`` but only correct for equally spaced nodes
+        (cf. `is_equidistant`).
 
     Returns
     -------
@@ -112,7 +127,12 @@ def get_bracketing_indices(x, nodes):
         zero = np.zeros_like(x, dtype=int)
         return zero, zero
 
-    i_upper = np.array(np.clip(np.searchsorted(nodes, x, side='left'), 1, n - 1), dtype=int)
+    if equidistant:
+        i_upper = np.ceil((x - nodes[0]) / (nodes[-1] - nodes[0]) * (n - 1))
+    else:
+        i_upper = np.searchsorted(nodes, x, side='left')
+
+    i_upper = np.array(np.clip(i_upper, 1, n - 1), dtype=int)
     return i_upper - 1, i_upper
 
 
@@ -1420,6 +1440,11 @@ class AntennaPattern(AntennaPatternBase):
         self.n_theta = len(self.theta_angles)
         self.n_phi = len(self.phi_angles)
 
+        # allows the faster index calculation in `get_bracketing_indices`
+        self._equidistant_freqs = is_equidistant(self.frequencies)
+        self._equidistant_theta = is_equidistant(self.theta_angles)
+        self._equidistant_phi = is_equidistant(self.phi_angles)
+
         self.VEL_phi = H_phi
         self.VEL_theta = H_theta
 
@@ -1478,15 +1503,18 @@ class AntennaPattern(AntennaPatternBase):
         # the angular and frequency grids are not necessarily equally spaced (e.g. the
         # theta grid of RNOG_vpol_4inch_center_n1.73), hence look up the bracketing
         # nodes instead of calculating their indices from the grid boundaries
-        iTheta_lower, iTheta_upper = get_bracketing_indices(theta, self.theta_angles)
+        iTheta_lower, iTheta_upper = get_bracketing_indices(
+            theta, self.theta_angles, self._equidistant_theta)
         theta_lower = self.theta_angles[iTheta_lower]
         theta_upper = self.theta_angles[iTheta_upper]
 
-        iPhi_lower, iPhi_upper = get_bracketing_indices(phi, self.phi_angles)
+        iPhi_lower, iPhi_upper = get_bracketing_indices(
+            phi, self.phi_angles, self._equidistant_phi)
         phi_lower = self.phi_angles[iPhi_lower]
         phi_upper = self.phi_angles[iPhi_upper]
 
-        iFrequency_lower, iFrequency_upper = get_bracketing_indices(freq, self.frequencies)
+        iFrequency_lower, iFrequency_upper = get_bracketing_indices(
+            freq, self.frequencies, self._equidistant_freqs)
         # handling frequency out of bound cases properly
         out_of_bound_freqs_low = freq < self.frequency_lower_bound
         out_of_bound_freqs_high = freq > self.frequency_upper_bound

--- a/NuRadioReco/detector/test/test_antennapattern.py
+++ b/NuRadioReco/detector/test/test_antennapattern.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""
+Tests for the antenna pattern interpolation.
+
+Regression test for the bracketing of non-equidistant grids: the antenna models are
+not required to be sampled on an equally spaced grid (e.g. RNOG_vpol_4inch_center_n1.73
+has theta nodes [0, 30, 60, 70, 80, 90, 100, 110, 120, 150, 180] deg). Deriving the
+node indices from the grid boundaries instead of looking them up produced
+discontinuities of up to 70 % in the vector effective length.
+"""
+import numpy as np
+
+from NuRadioReco.detector.antennapattern import AntennaPatternProvider, get_bracketing_indices
+from NuRadioReco.utilities import units
+
+
+def test_get_bracketing_indices():
+    nodes = np.array([0., 30., 60., 70., 80., 90., 100., 110., 120., 150., 180.])
+
+    # values in between two nodes
+    for x, expected in [(15., (0, 1)), (65., (2, 3)), (135., (8, 9)), (179.9, (9, 10))]:
+        assert tuple(np.atleast_1d(i)[0] for i in get_bracketing_indices(x, nodes)) == expected, \
+            "wrong bracket for x = {}".format(x)
+
+    # values on a node have to be bracketed such that the interpolation returns the node
+    for i, x in enumerate(nodes):
+        i_lower, i_upper = get_bracketing_indices(x, nodes)
+        assert nodes[i_lower] <= x <= nodes[i_upper]
+        assert i_upper - i_lower <= 1
+
+    # out-of-range values are clamped to the outermost interval
+    assert tuple(np.atleast_1d(i)[0] for i in get_bracketing_indices(-10., nodes)) == (0, 1)
+    assert tuple(np.atleast_1d(i)[0] for i in get_bracketing_indices(200., nodes)) == (9, 10)
+
+    # array input and a single-node grid
+    i_lower, i_upper = get_bracketing_indices(np.array([15., 65.]), nodes)
+    assert np.all(i_lower == [0, 2]) and np.all(i_upper == [1, 3])
+    i_lower, i_upper = get_bracketing_indices(np.array([1., 2.]), np.array([5.]))
+    assert np.all(i_lower == 0) and np.all(i_upper == 0)
+
+
+def test_vel_is_continuous():
+    """The interpolated VEL must not jump between two adjacent zenith angles"""
+    provider = AntennaPatternProvider()
+    antenna = provider.load_antenna_pattern("RNOG_vpol_4inch_center_n1.73")
+
+    zeniths = np.arange(0, 180, 0.1) * units.deg
+    freq = np.array([200]) * units.MHz
+    orientation = [0, 0, np.pi / 2, np.pi / 2]
+
+    for azimuth in np.arange(0, 360, 20) * units.deg:
+        vel = np.array([np.abs(antenna.get_antenna_response_vectorized(
+            freq, zenith, azimuth, *orientation)["theta"]) for zenith in zeniths]).flatten()
+
+        steps = np.abs(np.diff(vel))
+        # a smooth curve on this fine a grid stays close to its typical step size
+        assert steps.max() < 10 * np.median(steps), \
+            "VEL jumps by {:.2e} at zenith = {:.1f} deg (azimuth = {:.0f} deg), " \
+            "typical step is {:.2e}".format(
+                steps.max(), zeniths[np.argmax(steps)] / units.deg,
+                azimuth / units.deg, np.median(steps))
+
+
+if __name__ == "__main__":
+    test_get_bracketing_indices()
+    test_vel_is_continuous()
+    print("Antenna pattern tests passed")

--- a/NuRadioReco/detector/test/test_antennapattern.py
+++ b/NuRadioReco/detector/test/test_antennapattern.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python3
 """
-Tests for the antenna pattern interpolation.
+Tests for NuRadioReco.detector.antennapattern
+
+The tests are split into two groups: everything up to `test_provider_buffering` runs
+without any antenna model file, the tests after it need RNOG_vpol_4inch_center_n1.73
+(~10 MB, downloaded on first use).
 
 Regression test for the bracketing of non-equidistant grids: the antenna models are
 not required to be sampled on an equally spaced grid (e.g. RNOG_vpol_4inch_center_n1.73
@@ -11,8 +15,71 @@ discontinuities of up to 70 % in the vector effective length.
 import numpy as np
 
 from NuRadioReco.detector.antennapattern import (
-    AntennaPatternProvider, get_bracketing_indices, is_equidistant)
+    AntennaPattern, AntennaPatternAnalytic, AntennaPatternProvider, get_bracketing_indices,
+    get_group_delay, interpolate_linear, interpolate_linear_vectorized, is_equidistant)
 from NuRadioReco.utilities import units
+
+TEST_MODEL = "RNOG_vpol_4inch_center_n1.73"
+
+
+def expect_known_issue(func, description):
+    """
+    Run a check which documents a known defect, i.e. which is expected to fail
+
+    Raises if the check passes, which is the signal that the defect was fixed and that
+    the check should be turned into a regular assertion.
+    """
+    try:
+        func()
+    except AssertionError:
+        print("  known issue (still present): {}".format(description))
+        return
+
+    raise AssertionError(
+        "'{}' does not reproduce anymore, please turn it into a regular test".format(description))
+
+
+# --------------------------------------------------------------------------------------
+# interpolation helpers
+# --------------------------------------------------------------------------------------
+
+def test_interpolate_linear():
+    y0, y1 = 1 + 1j, 3 - 2j
+
+    for method in ["complex", "magphase"]:
+        # the endpoints have to be reproduced exactly by both methods
+        assert np.isclose(interpolate_linear(0., 0., 1., y0, y1, method), y0)
+        assert np.isclose(interpolate_linear(1., 0., 1., y0, y1, method), y1)
+
+    # complex interpolation is linear in real and imaginary part
+    assert np.isclose(interpolate_linear(0.5, 0., 1., y0, y1), 0.5 * (y0 + y1))
+
+    # magphase interpolation is linear in magnitude
+    mid = interpolate_linear(0.5, 0., 1., y0, y1, "magphase")
+    assert np.isclose(np.abs(mid), 0.5 * (np.abs(y0) + np.abs(y1)))
+
+    # a degenerate interval returns the first value
+    assert interpolate_linear(5., 1., 1., y0, y1) == y0
+
+    try:
+        interpolate_linear(0.5, 0., 1., y0, y1, "does_not_exist")
+    except NotImplementedError:
+        pass
+    else:
+        raise AssertionError("unknown interpolation method has to raise")
+
+
+def test_interpolate_linear_vectorized():
+    """The vectorized variant has to agree with the scalar one, including x0 == x1"""
+    x = np.array([0.5, 1.0, 2.0])
+    x0, x1 = np.array([0., 1., 2.]), np.array([1., 1., 3.])
+    y0 = np.array([1 + 0j, 5 + 0j, 2 + 2j])
+    y1 = np.array([3 + 0j, 9 + 0j, 4 + 4j])
+
+    for method in ["complex", "magphase"]:
+        vectorized = interpolate_linear_vectorized(x, x0, x1, y0, y1, method)
+        scalar = [interpolate_linear(x[i], x0[i], x1[i], y0[i], y1[i], method) for i in range(len(x))]
+        assert np.allclose(vectorized, scalar), "vectorized and scalar disagree for {}".format(method)
 
 
 def test_get_bracketing_indices():
@@ -24,7 +91,7 @@ def test_get_bracketing_indices():
             "wrong bracket for x = {}".format(x)
 
     # values on a node have to be bracketed such that the interpolation returns the node
-    for i, x in enumerate(nodes):
+    for x in nodes:
         i_lower, i_upper = get_bracketing_indices(x, nodes)
         assert nodes[i_lower] <= x <= nodes[i_upper]
         assert i_upper - i_lower <= 1
@@ -53,30 +120,237 @@ def test_equidistant_shortcut():
         assert np.all(grid[i_slow] == grid[i_fast])
 
 
-def test_vel_is_continuous():
-    """The interpolated VEL must not jump between two adjacent zenith angles"""
-    provider = AntennaPatternProvider()
-    antenna = provider.load_antenna_pattern("RNOG_vpol_4inch_center_n1.73")
+def test_get_group_delay():
+    """A pure delay has a constant group delay of exactly that delay"""
+    df = 10 * units.MHz
+    freqs = np.arange(0, 1000) * df
+    delay = 12.3 * units.ns
 
-    zeniths = np.arange(0, 180, 0.1) * units.deg
-    freq = np.array([200]) * units.MHz
+    group_delay = get_group_delay(np.exp(-1j * 2 * np.pi * freqs * delay), df)
+    assert np.allclose(group_delay, delay)
+
+
+# --------------------------------------------------------------------------------------
+# coordinate transformation (AntennaPatternBase)
+# --------------------------------------------------------------------------------------
+
+def test_antenna_rotation():
+    antenna = AntennaPatternAnalytic("analytic_LPDA")
+    own_orientation = [antenna._orientation_theta, antenna._orientation_phi,
+                       antenna._rotation_theta, antenna._rotation_phi]
+
+    # deploying the antenna exactly as it was simulated must not rotate anything
+    assert np.allclose(antenna._get_antenna_rotation(*own_orientation), np.eye(3))
+
+    for zenith, azimuth in [(30 * units.deg, 40 * units.deg), (120 * units.deg, 200 * units.deg)]:
+        theta, phi = antenna._get_theta_and_phi(zenith, azimuth, *own_orientation)
+        assert np.isclose(theta, zenith)
+        assert np.isclose(np.exp(1j * phi), np.exp(1j * azimuth))  # phi is returned in (-180, 180] deg
+
+    # orientation and rotation have to be perpendicular
+    try:
+        antenna._get_antenna_rotation(0., 0., 0., 0.)
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("a degenerate antenna orientation has to raise")
+
+
+# --------------------------------------------------------------------------------------
+# analytic antenna models
+# --------------------------------------------------------------------------------------
+
+def test_analytic_patterns():
+    freqs = np.arange(50, 1001, 10) * units.MHz
+    zeniths = np.arange(0, 181, 10) * units.deg
+    azimuths = np.arange(0, 360, 30) * units.deg
+
+    for model, max_VEL in [("analytic_LPDA", 0.55 * units.m),
+                           ("analytic_VPol", 0.18 * units.m),
+                           ("analytic_HPol", 0.055 * units.m)]:
+        antenna = AntennaPatternAnalytic(model)
+        scaled = AntennaPatternAnalytic(model, max_VEL=2 * max_VEL)
+        orientation = [antenna._orientation_theta, antenna._orientation_phi,
+                       antenna._rotation_theta, antenna._rotation_phi]
+
+        peak, peak_scaled = 0, 0
+        for zenith in zeniths:
+            for azimuth in azimuths:
+                vel = antenna.get_antenna_response_vectorized(freqs, zenith, azimuth, *orientation)
+                assert np.all(np.isfinite(vel["theta"])) and np.all(np.isfinite(vel["phi"]))
+                assert len(vel["theta"]) == len(freqs)
+                peak = max(peak, np.abs(vel["theta"]).max(), np.abs(vel["phi"]).max())
+
+                vel = scaled.get_antenna_response_vectorized(freqs, zenith, azimuth, *orientation)
+                peak_scaled = max(peak_scaled, np.abs(vel["theta"]).max(), np.abs(vel["phi"]).max())
+
+        assert np.isclose(peak, max_VEL), \
+            "{}: peak |VEL| {:.4f} != max_VEL {:.4f}".format(model, peak, max_VEL)
+        assert np.isclose(peak_scaled, 2 * max_VEL), "{}: max_VEL is not applied".format(model)
+
+    # the cutoff frequency has to be picked up as well
+    default = AntennaPatternAnalytic("analytic_VPol")
+    shifted = AntennaPatternAnalytic("analytic_VPol", cutoff_freq=400 * units.MHz)
+    assert shifted._cutoff_freq == 400 * units.MHz
+    orientation = [default._orientation_theta, default._orientation_phi,
+                   default._rotation_theta, default._rotation_phi]
+    assert not np.allclose(
+        default.get_antenna_response_vectorized(freqs, 90 * units.deg, 0., *orientation)["theta"],
+        shifted.get_antenna_response_vectorized(freqs, 90 * units.deg, 0., *orientation)["theta"])
+
+
+def test_parametric_phase():
+    antenna = AntennaPatternAnalytic("analytic_LPDA")
+    freqs = np.linspace(50, 1000, 100) * units.MHz
+
+    for phase_type in ["frontlobe_lpda", "side_lpda", "back_lpda", "theoretical",
+                       "VPol_third_order", "HPol_third_order"]:
+        phase = antenna.parametric_phase(freqs, phase_type)
+        assert np.shape(phase) == np.shape(freqs)
+        assert np.all(np.isfinite(phase)), "{} returns non-finite values".format(phase_type)
+
+
+# --------------------------------------------------------------------------------------
+# AntennaPatternProvider
+# --------------------------------------------------------------------------------------
+
+def test_provider_buffering():
+    provider = AntennaPatternProvider()
+
+    # the provider is a singleton and buffers the (expensive to load) patterns
+    assert AntennaPatternProvider() is provider
+    antenna = provider.load_antenna_pattern("analytic_LPDA")
+    assert provider.load_antenna_pattern("analytic_LPDA") is antenna
+
+    # names starting with "analytic" are dispatched to the analytic implementation
+    assert isinstance(antenna, AntennaPatternAnalytic)
+
+    def buffer_survives_reinstantiation():
+        provider = AntennaPatternProvider()
+        antenna = provider.load_antenna_pattern("analytic_LPDA")
+        AntennaPatternProvider()  # __init__ runs again on the singleton
+        assert provider.load_antenna_pattern("analytic_LPDA") is antenna
+
+    def kwargs_are_honoured():
+        provider = AntennaPatternProvider()
+        provider.load_antenna_pattern("analytic_LPDA")
+        antenna = provider.load_antenna_pattern("analytic_LPDA", max_VEL=1 * units.m)
+        assert antenna._max_VEL == 1 * units.m
+
+    # `__init__` resets the buffer on every instantiation, so the pattern is loaded again
+    expect_known_issue(buffer_survives_reinstantiation,
+                       "AntennaPatternProvider() empties the buffer of the singleton")
+    # kwargs are ignored as soon as the model is buffered
+    expect_known_issue(kwargs_are_honoured,
+                       "load_antenna_pattern ignores kwargs for an already buffered model")
+
+
+# --------------------------------------------------------------------------------------
+# AntennaPattern, these need the antenna model file
+# --------------------------------------------------------------------------------------
+
+def test_interpolation_at_nodes():
+    """At a grid node the interpolation has to return the tabulated value"""
+    antenna = AntennaPattern(TEST_MODEL)
+
+    for i_freq in [0, 100, antenna.n_freqs - 1]:
+        for i_theta in range(antenna.n_theta):
+            for i_phi in range(0, antenna.n_phi, 3):
+                index = antenna._get_index(i_freq, i_theta, i_phi)
+                vel = antenna._get_antenna_response_vectorized_raw(
+                    np.array([antenna.frequencies[i_freq]]),
+                    antenna.theta_angles[i_theta], antenna.phi_angles[i_phi])
+
+                assert np.allclose(vel[0], antenna.VEL_theta[index], atol=1e-15)
+                assert np.allclose(vel[1], antenna.VEL_phi[index], atol=1e-15)
+
+
+def test_magphase_agrees_at_nodes():
+    """Both interpolation methods are only allowed to differ in between the nodes"""
+    complex_ = AntennaPattern(TEST_MODEL, interpolation_method="complex")
+    magphase = AntennaPattern(TEST_MODEL, interpolation_method="magphase")
+    freqs = np.array([complex_.frequencies[100]])
+
+    for i_theta in range(complex_.n_theta):
+        for i_phi in range(0, complex_.n_phi, 3):
+            theta, phi = complex_.theta_angles[i_theta], complex_.phi_angles[i_phi]
+            assert np.allclose(
+                np.array(complex_._get_antenna_response_vectorized_raw(freqs, theta, phi)),
+                np.array(magphase._get_antenna_response_vectorized_raw(freqs, theta, phi)),
+                atol=1e-15)
+
+
+def test_phi_wrapping():
+    """Azimuth angles outside the tabulated range are wrapped, not clipped"""
+    antenna = AntennaPatternProvider().load_antenna_pattern(TEST_MODEL)
+    freqs = np.array([200., 300.]) * units.MHz
     orientation = [0, 0, np.pi / 2, np.pi / 2]
 
-    for azimuth in np.arange(0, 360, 20) * units.deg:
-        vel = np.array([np.abs(antenna.get_antenna_response_vectorized(
-            freq, zenith, azimuth, *orientation)["theta"]) for zenith in zeniths]).flatten()
+    for azimuth in [30, 100, 200]:
+        inside = antenna.get_antenna_response_vectorized(
+            freqs, 1., azimuth * units.deg, *orientation)
+        wrapped = antenna.get_antenna_response_vectorized(
+            freqs, 1., (azimuth - 360) * units.deg, *orientation)
 
-        steps = np.abs(np.diff(vel))
-        # a smooth curve on this fine a grid stays close to its typical step size
-        assert steps.max() < 10 * np.median(steps), \
-            "VEL jumps by {:.2e} at zenith = {:.1f} deg (azimuth = {:.0f} deg), " \
-            "typical step is {:.2e}".format(
-                steps.max(), zeniths[np.argmax(steps)] / units.deg,
-                azimuth / units.deg, np.median(steps))
+        for component in ["theta", "phi"]:
+            assert np.allclose(inside[component], wrapped[component]), \
+                "azimuth {} deg and {} deg give different responses".format(azimuth, azimuth - 360)
+
+
+def test_out_of_range():
+    """Directions outside the tabulated range return zeros"""
+    antenna = AntennaPattern(TEST_MODEL)
+    freqs = np.array([200., 300., 400.]) * units.MHz
+
+    vel = antenna._get_antenna_response_vectorized_raw(freqs, 200 * units.deg, 0.)
+    assert np.all(np.array(vel) == 0)
+
+    def shape_matches_frequencies():
+        vel = antenna._get_antenna_response_vectorized_raw(freqs, 200 * units.deg, 0.)
+        assert np.shape(vel)[1] == len(freqs)
+
+    # the in-range path returns one value per frequency, the out-of-range path a single one
+    expect_known_issue(shape_matches_frequencies,
+                       "out-of-range directions return shape (2, 1) instead of (2, n_freqs)")
+
+
+def test_vel_is_continuous():
+    """The interpolated VEL must not jump between two adjacent zenith angles"""
+    antenna = AntennaPatternProvider().load_antenna_pattern(TEST_MODEL)
+
+    # the theta/phi unit vectors are degenerate at the poles, stay away from them
+    zeniths = np.arange(1, 179, 0.1) * units.deg
+    orientation = [0, 0, np.pi / 2, np.pi / 2]
+
+    for freq in np.array([100., 200., 600.]) * units.MHz:
+        for azimuth in np.arange(0, 360, 45) * units.deg:
+            response = [antenna.get_antenna_response_vectorized(
+                np.array([freq]), zenith, azimuth, *orientation) for zenith in zeniths]
+
+            for component in ["theta", "phi"]:
+                vel = np.abs(np.array([r[component] for r in response])).flatten()
+                steps = np.abs(np.diff(vel))
+
+                # a smooth curve on this fine a grid stays close to its typical step size
+                assert steps.max() < 10 * np.median(steps), \
+                    "VEL_{} jumps by {:.2e} at zenith = {:.1f} deg (azimuth = {:.0f} deg, " \
+                    "{:.0f} MHz), typical step is {:.2e}".format(
+                        component, steps.max(), zeniths[np.argmax(steps)] / units.deg,
+                        azimuth / units.deg, freq / units.MHz, np.median(steps))
 
 
 if __name__ == "__main__":
-    test_get_bracketing_indices()
-    test_equidistant_shortcut()
-    test_vel_is_continuous()
-    print("Antenna pattern tests passed")
+    without_antenna_file = [
+        test_interpolate_linear, test_interpolate_linear_vectorized, test_get_bracketing_indices,
+        test_equidistant_shortcut, test_get_group_delay, test_antenna_rotation,
+        test_analytic_patterns, test_parametric_phase, test_provider_buffering]
+
+    with_antenna_file = [
+        test_interpolation_at_nodes, test_magphase_agrees_at_nodes, test_phi_wrapping,
+        test_out_of_range, test_vel_is_continuous]
+
+    for test in without_antenna_file + with_antenna_file:
+        print("{} ...".format(test.__name__))
+        test()
+
+    print("\nAntenna pattern tests passed")

--- a/NuRadioReco/detector/test/test_antennapattern.py
+++ b/NuRadioReco/detector/test/test_antennapattern.py
@@ -10,7 +10,8 @@ discontinuities of up to 70 % in the vector effective length.
 """
 import numpy as np
 
-from NuRadioReco.detector.antennapattern import AntennaPatternProvider, get_bracketing_indices
+from NuRadioReco.detector.antennapattern import (
+    AntennaPatternProvider, get_bracketing_indices, is_equidistant)
 from NuRadioReco.utilities import units
 
 
@@ -39,6 +40,19 @@ def test_get_bracketing_indices():
     assert np.all(i_lower == 0) and np.all(i_upper == 0)
 
 
+def test_equidistant_shortcut():
+    """On an equally spaced grid the fast index calculation must match the lookup"""
+    assert not is_equidistant(np.array([0., 30., 60., 70., 80., 90., 100., 110., 120., 150., 180.]))
+    assert is_equidistant(np.arange(0., 181., 5.))
+    assert is_equidistant(np.arange(0., 181., 5.) + 1e-6 * np.arange(37))  # rounding of the raw file
+
+    grid = np.arange(0., 181., 5.)
+    x = np.concatenate([np.linspace(0, 180, 1001), grid])
+    for i_slow, i_fast in zip(get_bracketing_indices(x, grid),
+                              get_bracketing_indices(x, grid, equidistant=True)):
+        assert np.all(grid[i_slow] == grid[i_fast])
+
+
 def test_vel_is_continuous():
     """The interpolated VEL must not jump between two adjacent zenith angles"""
     provider = AntennaPatternProvider()
@@ -63,5 +77,6 @@ def test_vel_is_continuous():
 
 if __name__ == "__main__":
     test_get_bracketing_indices()
+    test_equidistant_shortcut()
     test_vel_is_continuous()
     print("Antenna pattern tests passed")

--- a/changelog.txt
+++ b/changelog.txt
@@ -24,6 +24,9 @@ from the NOAA ETOPO1 dataset via www.opentopodata.org.
 bugfixes:
 - Fixing bug in the simulation of non-trigger channels when an event is splitted into multiple events based on the signal arrival time.
   This is only relevant when simulating primaries and large detector arrays.
+- Fixing the interpolation of antenna models which are not sampled on an equally spaced grid. The node indices were calculated
+  from the grid boundaries, which silently picked the wrong nodes and extrapolated. Only RNOG_vpol_4inch_center_n1.73 (used in all
+  RNO_G detector descriptions) is affected, where the vector effective length was off by up to 70% at some zenith angles.
 
 deprecations:
 - Remove default values for `use_channels` and `bandpass` in voltageToAnalyticEfieldConverter.py and voltageToEfieldConverter.py which were suitable for ARIANNA.


### PR DESCRIPTION
This fixes an annoying bug which was included since the beginning. 

To find for e.g. a value of `theta` the nodes in the stored antenna pattern which bracket `theta` the code assumes an equidistant spacing of the `theta_nodes`. However, it is never checked that the nodes are equidistant spaced... 

This PR introduces a generic function to find the backeting indices. But since this is a bit slower, we fall back to the original code assuming equidistant nodes if the nodes are actually equidistant. 

Also adding some unit tests to catch these bugs in the future. 

Implementation is mostly made by Claude... 

Big thanks to @CassandraMcGinley for finding this bug and already providing information about the cause! 